### PR TITLE
Added ORM adapter layer to allow use of Sequel

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ Metrics/BlockLength:
   Exclude:
     - 'Rakefile'
     - '**/*.rake'
+    - '**/*.gemspec'
     - '**/spec/**/*.rb'
 Metrics/LineLength:
   Max: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (2018-01-15)
+
+* Added ORM adapter layer to allow use of [Sequel](https://github.com/jeremyevans/sequel)
+
 ## 1.0.1 (2018-01-06)
 
 * Refactoring and code cleanup

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  gem 'bundler'
-  gem 'combustion'
-  gem 'coveralls'
-  gem 'pry-byebug'
-  gem 'que-testing'
-  gem 'railties', '>= 4.0'
-  gem 'rake'
-  gem 'reek'
-  gem 'rspec'
-  gem 'rubocop'
-  gem 'timecop'
-  gem 'zonebie'
-end

--- a/lib/que/scheduler.rb
+++ b/lib/que/scheduler.rb
@@ -1,3 +1,6 @@
 require 'que/scheduler/version'
 require 'que/scheduler/scheduler_job'
-require 'que/scheduler/engine' if Gem::Specification.find_by_name('railties')
+require 'que/scheduler/adapters/orm'
+# rubocop:disable Style/PreferredHashMethods
+require 'que/scheduler/engine' if Gem.loaded_specs.has_key?('railties')
+# rubocop:enable Style/PreferredHashMethods

--- a/lib/que/scheduler/adapters/orm.rb
+++ b/lib/que/scheduler/adapters/orm.rb
@@ -1,0 +1,69 @@
+module Que
+  module Scheduler
+    module Adapters
+      module Orm
+        class AdapterBase
+          SCHEDULER_COUNT_SQL =
+            'SELECT COUNT(*) FROM que_jobs WHERE job_class = ' \
+            "'#{Que::Scheduler::SchedulerJob.name}'".freeze
+
+          def transaction
+            transaction_base.transaction do
+              yield
+            end
+          end
+
+          def count_schedulers
+            dml(SCHEDULER_COUNT_SQL).first.values.first.to_i
+          end
+        end
+
+        class ActiveRecordAdapter < AdapterBase
+          def transaction_base
+            ::ActiveRecord::Base
+          end
+
+          def dml(sql)
+            ::ActiveRecord::Base.connection.execute(sql)
+          end
+
+          def ddl(sql)
+            dml(sql)
+          end
+        end
+
+        class SequelAdapter < AdapterBase
+          def transaction_base
+            ::DB
+          end
+
+          def dml(sql)
+            ::DB.fetch(sql)
+          end
+
+          def ddl(sql)
+            ::DB.run(sql)
+          end
+        end
+
+        class << self
+          # The exposed mutator method here allows any future orm adapters to be tested.
+          attr_writer :instance
+
+          def instance
+            # rubocop:disable Style/PreferredHashMethods
+            @instance ||=
+              if Gem.loaded_specs.has_key?('activerecord')
+                ActiveRecordAdapter.new
+              elsif Gem.loaded_specs.has_key?('sequel')
+                SequelAdapter.new
+              else
+                raise 'No known ORM adapter is available for que-scheduler'
+              end
+            # rubocop:enable Style/PreferredHashMethods
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -57,7 +57,7 @@ module Que
 
       class << self
         def defined_jobs
-          @defined_jobs ||= YAML.load_file(QUE_SCHEDULER_CONFIG_LOCATION).map do |k, v|
+          @defined_jobs ||= YAML.safe_load(IO.read(QUE_SCHEDULER_CONFIG_LOCATION)).map do |k, v|
             Que::Scheduler::DefinedJob.new(
               {
                 name: k,

--- a/lib/que/scheduler/scheduler_job_args.rb
+++ b/lib/que/scheduler/scheduler_job_args.rb
@@ -1,4 +1,6 @@
 require 'hashie'
+require 'active_support'
+require 'active_support/time_with_zone'
 
 # These are the args that are used for this particular run of the scheduler.
 module Que
@@ -17,6 +19,7 @@ module Que
               job_dictionary: []
             }
           else
+            options = options.symbolize_keys
             {
               last_run_time: Time.zone.parse(options.fetch(:last_run_time)),
               job_dictionary: options.fetch(:job_dictionary)

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.0.2'.freeze
   end
 end

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -10,16 +10,32 @@ Gem::Specification.new do |spec|
   spec.email         = ['harry@harrylascelles.com']
 
   spec.summary       = 'A cron scheduler for Que'
-  spec.description   = 'A lightweight cron scheduler for the async job worker Que'
+  spec.description   = 'A lightweight cron scheduler for the Que async job worker'
   spec.homepage      = 'https://github.com/hlascelles/que-scheduler'
   spec.license       = 'MIT'
 
   spec.files = Dir['{lib}/**/*'] + ['README.md']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 4.0'
+  spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'backports', '~> 3.10'
   spec.add_dependency 'fugit', '~> 1'
   spec.add_dependency 'hashie', '~> 3'
   spec.add_dependency 'que', '~> 0.10'
+
+  spec.add_development_dependency 'activerecord', '>= 3.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'combustion'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'que-testing'
+  spec.add_development_dependency 'railties', '>= 3.0'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'reek'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'sequel', '>= 4.0'
+  spec.add_development_dependency 'sqlite3', '>= 1.3'
+  spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'zonebie'
 end

--- a/spec/que/scheduler/adapters/orm_spec.rb
+++ b/spec/que/scheduler/adapters/orm_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'active_record'
+require 'sequel'
+
+::DB = Sequel.sqlite
+::ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+
+RSpec.describe ::Que::Scheduler::Adapters::Orm do
+  context 'adapters' do
+    def perform_adapter_count_checks
+      adapter.ddl('CREATE TABLE que_jobs (job_class VARCHAR(255));')
+      adapter.ddl("INSERT INTO que_jobs values ('SomeJob');")
+      expect(adapter.count_schedulers).to eq(0)
+      adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
+      expect(adapter.count_schedulers).to eq(1)
+      adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
+      expect(adapter.count_schedulers).to eq(2)
+    end
+
+    def perform_adapter_transaction_check(underlying_orm)
+      expect(underlying_orm).to receive(:transaction) do |_, &block|
+        expect(block.call).to eq('test')
+      end
+      adapter.transaction do
+        'test'
+      end
+    end
+
+    let(:adapter) { described_class.new }
+
+    describe ::Que::Scheduler::Adapters::Orm::ActiveRecordAdapter do
+      it 'executes the correct SQL to count rows' do
+        perform_adapter_count_checks
+      end
+
+      it 'performs an action in a transaction' do
+        perform_adapter_transaction_check(::ActiveRecord::Base)
+      end
+    end
+
+    describe ::Que::Scheduler::Adapters::Orm::SequelAdapter do
+      it 'executes the correct SQL' do
+        perform_adapter_count_checks
+      end
+
+      it 'performs an action in a transaction' do
+        perform_adapter_transaction_check(::DB)
+      end
+    end
+  end
+
+  describe '.instance' do
+    before(:each) do
+      described_class.instance = nil
+    end
+
+    it 'returns the correct class for ActiveRecord' do
+      expect(Gem.loaded_specs).to receive(:has_key?).with('activerecord').and_return(true)
+      orm = described_class.instance
+      expect(orm.class).to eq(::Que::Scheduler::Adapters::Orm::ActiveRecordAdapter)
+    end
+
+    it 'returns the correct class for Sequel' do
+      expect(Gem.loaded_specs).to receive(:has_key?).with('activerecord').and_return(false)
+      expect(Gem.loaded_specs).to receive(:has_key?).with('sequel').and_return(true)
+      orm = described_class.instance
+      expect(orm.class).to eq(::Que::Scheduler::Adapters::Orm::SequelAdapter)
+    end
+
+    it 'errors for no orm' do
+      %w[activerecord sequel].each do |gem|
+        expect(Gem.loaded_specs).to receive(:has_key?).with(gem).and_return(false)
+      end
+      expect do
+        described_class.instance
+      end.to raise_error(/No known ORM adapter is available for que-scheduler/)
+    end
+  end
+end

--- a/spec/que/scheduler/enqueueing_calculator_spec.rb
+++ b/spec/que/scheduler/enqueueing_calculator_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
       HalfHourlyTestJob => [{}],
       WithArgsTestJob => [{ args: ['My Args', 1234, { 'some_hash' => true }] }],
       SpecifiedByClassTestJob => [{}],
-
       # These are "every_event", so all their missed schedules are enqueued, with that
       # Time as an argument.
       DailyTestJob => [

--- a/spec/que/scheduler/scheduler_job_args_spec.rb
+++ b/spec/que/scheduler/scheduler_job_args_spec.rb
@@ -11,17 +11,31 @@ RSpec.describe Que::Scheduler::SchedulerJobArgs do
     end
   end
 
-  it 'should parse current args' do
-    Timecop.freeze do
-      last_time = Time.zone.now - 45.minutes
-      dictionary = %w[HalfHourlyTestJob OldRemovedJob]
-      args = described_class.build(
+  describe 'should parse current args' do
+    let(:last_time) { Time.zone.now - 45.minutes }
+    let(:dictionary) { %w[HalfHourlyTestJob OldRemovedJob] }
+
+    def attempt_parse(options)
+      Timecop.freeze do
+        args = described_class.build(options)
+        expect(args.last_run_time.iso8601).to eq(last_time.iso8601)
+        expect(args.as_time).to eq(Time.zone.now)
+        expect(args.job_dictionary).to eq(dictionary)
+      end
+    end
+
+    it 'as symbols' do
+      attempt_parse(
         last_run_time: last_time.iso8601,
         job_dictionary: dictionary
       )
-      expect(args.last_run_time.iso8601).to eq(last_time.iso8601)
-      expect(args.as_time).to eq(Time.zone.now)
-      expect(args.job_dictionary).to eq(dictionary)
+    end
+
+    it 'as strings' do
+      attempt_parse(
+        'last_run_time' => last_time.iso8601,
+        'job_dictionary' => dictionary
+      )
     end
   end
 end

--- a/spec/que/scheduler/scheduler_job_spec.rb
+++ b/spec/que/scheduler/scheduler_job_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'que/testing'
 require 'timecop'
 require 'yaml'
-require 'active_record'
 require 'active_support/core_ext/numeric/time'
 
 RSpec.describe Que::Scheduler::SchedulerJob do
@@ -13,14 +12,10 @@ RSpec.describe Que::Scheduler::SchedulerJob do
 
   context 'scheduling' do
     before(:each) do
-      expect(::ActiveRecord::Base).to receive(:transaction) do |_, &block|
+      allow(QS::Adapters::Orm.instance).to receive(:count_schedulers).and_return(scheduler_jobs)
+      allow(QS::Adapters::Orm.instance).to receive(:transaction) do |_, &block|
         block.call
       end
-      connection = double('connection')
-      allow(ActiveRecord::Base).to receive(:connection) { connection }
-      expect(connection).to receive(:execute).with(
-        QSSJ::SCHEDULER_COUNT_SQL
-      ).and_return([{ 'count' => scheduler_jobs }])
       Que.adapter.jobs.clear
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV['QUE_SCHEDULER_CONFIG_LOCATION'] = "#{__dir__}/config/que_schedule.yml"
 # Require zonebie before any other gem to ensure it sets the correct test timezone.
 require 'zonebie/rspec'
 
-Bundler.require :default, :test
+Bundler.require :default, :development
 
 Dir["#{__dir__}/../spec/support/**/*.rb"].each { |f| require f }
 


### PR DESCRIPTION
ActiveRecord should not be a requirement to use this que-scheduler.