### PR TITLE
Codify dependency on `EtOrbi::EoTime#to_local_time`

### DIFF
--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'backports', '~> 3.10'
+  spec.add_dependency 'et-orbi', '> 1.0.5' # need the `#to_local_time` method
   spec.add_dependency 'fugit', '~> 1'
-  spec.add_dependency 'et-orbi', '> 1.0.5' # need the `to_local_time` method
   spec.add_dependency 'hashie', '~> 3'
   spec.add_dependency 'que', '~> 0.10'
 

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'backports', '~> 3.10'
   spec.add_dependency 'fugit', '~> 1'
+  spec.add_dependency 'et-orbi', '> 1.0.5' # need the `to_local_time` method
   spec.add_dependency 'hashie', '~> 3'
   spec.add_dependency 'que', '~> 0.10'
 


### PR DESCRIPTION
The code as written depends on the `EtOrbi::EoTime#to_local_time`
method. However, this method was not introduced until `et-orbi`
version `1.0.6`.

In cases where the bundle already contains a version of `et-orbi` that
is not updated to `1.0.6`, the code fails to execute because the
method does not exist yet.

fixes #4