### PR TITLE
Switch to using DB clock time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Switched to use DB time to find "now" so as to match que queries
+
 ## 1.0.3 (2018-03-15)
 
 * Enforced a minimum version of `et-orbi` to supply `#to_local_time` methods. Thanks to @jish.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ integers, and job classes must be migrated from Resque to Que. Cron syntax can b
 understood by [fugit](https://github.com/floraison/fugit#fugitcron).
 
 It has one additional feature, `schedule_type: every_event`. This is set on a job that must be run for every 
-single matching cron time that goes by, even if the system is offline over more than one match. To better process these `every_event` jobs, they are always enqueued with the first 
+single matching cron time that goes by, even if the system is offline over more than one match. 
+To better process these `every_event` jobs, they are always enqueued with the first 
 argument being the time that they were supposed to be processed.  
  
 For example:
@@ -137,3 +138,4 @@ This gem was inspired by the makers of the excellent [Que](https://github.com/ch
 ## Contributors
 
 * @jish
+* @joehorsnell

--- a/lib/que/scheduler/adapters/orm.rb
+++ b/lib/que/scheduler/adapters/orm.rb
@@ -6,6 +6,7 @@ module Que
           SCHEDULER_COUNT_SQL =
             'SELECT COUNT(*) FROM que_jobs WHERE job_class = ' \
             "'#{Que::Scheduler::SchedulerJob.name}'".freeze
+          NOW_SQL = 'SELECT now()'.freeze
 
           def transaction
             transaction_base.transaction do
@@ -15,6 +16,10 @@ module Que
 
           def count_schedulers
             dml(SCHEDULER_COUNT_SQL).first.values.first.to_i
+          end
+
+          def now
+            Time.zone.parse(dml(NOW_SQL).first.values.first)
           end
         end
 

--- a/lib/que/scheduler/scheduler_job_args.rb
+++ b/lib/que/scheduler/scheduler_job_args.rb
@@ -11,11 +11,12 @@ module Que
       property :as_time, required: true
 
       def self.build(options)
+        now = ::Que::Scheduler::Adapters::Orm.instance.now
         parsed =
           if options.nil?
-            # First ever run
+            # First ever run, there is nothing to do but reschedule self.
             {
-              last_run_time: Time.zone.now,
+              last_run_time: now,
               job_dictionary: []
             }
           else
@@ -25,7 +26,7 @@ module Que
               job_dictionary: options.fetch(:job_dictionary)
             }
           end
-        SchedulerJobArgs.new(parsed.merge(as_time: Time.zone.now))
+        SchedulerJobArgs.new(parsed.merge(as_time: now))
       end
     end
   end

--- a/spec/que/scheduler/adapters/orm_spec.rb
+++ b/spec/que/scheduler/adapters/orm_spec.rb
@@ -4,47 +4,48 @@ require 'sequel'
 
 ::DB = Sequel.sqlite
 ::ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+QSAO = ::Que::Scheduler::Adapters::Orm
 
-RSpec.describe ::Que::Scheduler::Adapters::Orm do
-  context 'adapters' do
-    def perform_adapter_count_checks
-      adapter.ddl('CREATE TABLE que_jobs (job_class VARCHAR(255));')
-      adapter.ddl("INSERT INTO que_jobs values ('SomeJob');")
-      expect(adapter.count_schedulers).to eq(0)
-      adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
-      expect(adapter.count_schedulers).to eq(1)
-      adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
-      expect(adapter.count_schedulers).to eq(2)
-    end
+RSpec.describe QSAO do
+  {
+    QSAO::ActiveRecordAdapter => ::ActiveRecord::Base,
+    QSAO::SequelAdapter => ::DB
+  }.each do |adapters, connection|
+    describe adapters do
+      let(:adapter) { described_class.new }
 
-    def perform_adapter_transaction_check(underlying_orm)
-      expect(underlying_orm).to receive(:transaction) do |_, &block|
-        expect(block.call).to eq('test')
-      end
-      adapter.transaction do
-        'test'
-      end
-    end
-
-    let(:adapter) { described_class.new }
-
-    describe ::Que::Scheduler::Adapters::Orm::ActiveRecordAdapter do
-      it 'executes the correct SQL to count rows' do
-        perform_adapter_count_checks
+      describe '#count_schedulers' do
+        it 'finds the right number of rows' do
+          adapter.ddl('CREATE TABLE que_jobs (job_class VARCHAR(255));')
+          adapter.ddl("INSERT INTO que_jobs values ('SomeJob');")
+          expect(adapter.count_schedulers).to eq(0)
+          adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
+          expect(adapter.count_schedulers).to eq(1)
+          adapter.ddl("INSERT INTO que_jobs values ('Que::Scheduler::SchedulerJob');")
+          expect(adapter.count_schedulers).to eq(2)
+        end
       end
 
-      it 'performs an action in a transaction' do
-        perform_adapter_transaction_check(::ActiveRecord::Base)
+      describe '#transaction' do
+        it 'starts a transaction correctly' do
+          expect(connection).to receive(:transaction) do |_, &block|
+            expect(block.call).to eq('test')
+          end
+          adapter.transaction do
+            'test'
+          end
+        end
       end
-    end
 
-    describe ::Que::Scheduler::Adapters::Orm::SequelAdapter do
-      it 'executes the correct SQL' do
-        perform_adapter_count_checks
-      end
-
-      it 'performs an action in a transaction' do
-        perform_adapter_transaction_check(::DB)
+      describe '#now' do
+        it 'returns the value from the DB' do
+          expect(adapter).to receive(:dml).with('SELECT now()').and_return(
+            [{ 'now' => '2018-03-24 10:18:29.079874+01' }]
+          )
+          # Check the time parsing handles timezones by expecting a different time in a different
+          # timezone.
+          expect(adapter.now).to eq(Time.zone.parse('2018-03-24 09:18:29.079874+00'))
+        end
       end
     end
   end
@@ -57,14 +58,14 @@ RSpec.describe ::Que::Scheduler::Adapters::Orm do
     it 'returns the correct class for ActiveRecord' do
       expect(Gem.loaded_specs).to receive(:has_key?).with('activerecord').and_return(true)
       orm = described_class.instance
-      expect(orm.class).to eq(::Que::Scheduler::Adapters::Orm::ActiveRecordAdapter)
+      expect(orm.class).to eq(QSAO::ActiveRecordAdapter)
     end
 
     it 'returns the correct class for Sequel' do
       expect(Gem.loaded_specs).to receive(:has_key?).with('activerecord').and_return(false)
       expect(Gem.loaded_specs).to receive(:has_key?).with('sequel').and_return(true)
       orm = described_class.instance
-      expect(orm.class).to eq(::Que::Scheduler::Adapters::Orm::SequelAdapter)
+      expect(orm.class).to eq(QSAO::SequelAdapter)
     end
 
     it 'errors for no orm' do

--- a/spec/que/scheduler/scheduler_job_args_spec.rb
+++ b/spec/que/scheduler/scheduler_job_args_spec.rb
@@ -4,6 +4,7 @@ require 'timecop'
 RSpec.describe Que::Scheduler::SchedulerJobArgs do
   it 'should prepare default args' do
     Timecop.freeze do
+      apply_db_time_now
       args = described_class.build(nil)
       expect(args.last_run_time).to eq(Time.zone.now)
       expect(args.as_time).to eq(Time.zone.now)
@@ -17,6 +18,7 @@ RSpec.describe Que::Scheduler::SchedulerJobArgs do
 
     def attempt_parse(options)
       Timecop.freeze do
+        apply_db_time_now
         args = described_class.build(options)
         expect(args.last_run_time.iso8601).to eq(last_time.iso8601)
         expect(args.as_time).to eq(Time.zone.now)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,7 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+  config.before(:each) do
+    Que.adapter.jobs.clear
+  end
 end

--- a/spec/support/time_support.rb
+++ b/spec/support/time_support.rb
@@ -1,0 +1,3 @@
+def apply_db_time_now
+  allow(QS::Adapters::Orm.instance).to receive(:now).and_return(Time.zone.now)
+end


### PR DESCRIPTION
The previous version of que-scheduler used `Time.zone.now` to find the current time. To be more certain of correct "overdue" queries by que, we should be using the DB reported time for "now".

Thanks to @joehorsnell!