### PR TITLE
Use fugit with timezone support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
+- 2.1
+- 2.2
+- 2.3
+- 2.4
 env:
   global:
-    - TZ=Europe/London
+  - TZ=Europe/London
+before_install:
+- export TZ=Europe/London
 script:
-  - bundle exec rspec -fd -b -P ./spec/**/*_spec.rb
+- bundle exec rspec -fd -b -P ./spec/**/*_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0 (2018-03-29)
+
+* Upgraded [fugit](https://github.com/floraison/fugit/issues/2) to allow timezones in cron lines 
+
 ## 1.1.0 (2018-03-24)
 
 * Switched to use DB time to find "now" so as to match que queries
@@ -22,7 +26,7 @@
 
 ## 0.10.1 (2017-12-03)
 
-* Added `schedule_type` config key.
+* Added `schedule_type` config key
 
 ## 0.9.1 (2017-12-03)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For example:
 CancelAbandonedOrders:
   cron: "*/5 * * * *"
 
-# Specify the job_class, using any name for the key.
+# Specify the job_class, using any name for the key
 queue_documents_for_indexing:
   cron: "0 0 * * *"
   class: QueueDocuments
@@ -67,12 +67,16 @@ SendOrders:
   cron: "0 0 * * *"
   args: ['open']
   
-# Use simpler cron syntax.
+# Use simpler cron syntax
 SendBilling:
   cron: "@daily"
+  
+# Use timezone cron syntax
+SendCoupons:
+  cron: "0 7 * * * America/Los_Angeles"
 
 # Altogether now
-all_args_job:
+all_options_job:
   cron: "0 0 * * *"
   class: QueueDocuments
   queue: reporting

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -26,7 +26,7 @@ module Que
         job_class = Object.const_get(v)
         job_class < Que::Job ? job_class : err_field(:job_class, v)
       }
-      property :cron, transform_with: ->(v) { Fugit::Cron.new(v) || err_field(:cron, v) }
+      property :cron, transform_with: ->(v) { Fugit::Cron.parse(v) || err_field(:cron, v) }
       property :queue, transform_with: ->(v) { v.is_a?(String) ? v : err_field(:queue, v) }
       property :priority, transform_with: ->(v) { v.is_a?(Integer) ? v : err_field(:priority, v) }
       property :args

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -1,5 +1,5 @@
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'que/scheduler/version'
 
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'backports', '~> 3.10'
-  spec.add_dependency 'et-orbi', '> 1.0.5' # need the `#to_local_time` method
-  spec.add_dependency 'fugit', '~> 1'
+  spec.add_dependency 'fugit', '~> 1.1'
   spec.add_dependency 'hashie', '~> 3'
   spec.add_dependency 'que', '~> 0.10'
 

--- a/spec/config/que_schedule.yml
+++ b/spec/config/que_schedule.yml
@@ -27,3 +27,7 @@ TwiceDailyTestJob:
   priority: 35
   queue: backlog
   schedule_type: every_event
+
+TimezoneTestJob:
+  cron: "5 7 1 * * America/Los_Angeles"
+  schedule_type: every_event

--- a/spec/que/scheduler/defined_job_spec.rb
+++ b/spec/que/scheduler/defined_job_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Que::Scheduler::DefinedJob do
       expect(job.cron.to_cron_s).to eq('0 0 * * 0')
     end
 
+    it 'allows crons with fugit compatible timezones' do
+      job = described_class.new(
+        name: 'testing_job_definitions',
+        job_class: 'HalfHourlyTestJob',
+        cron: '0 7 * * * America/Los_Angeles'
+      )
+      expect(job.cron.zone).to eq('America/Los_Angeles')
+    end
+
     it 'checks the queue is a string' do
       expect do
         described_class.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ ENV['QUE_SCHEDULER_CONFIG_LOCATION'] = "#{__dir__}/config/que_schedule.yml"
 # zonebie. If you want to force one particular timezone, you can use the following:
 # ENV['ZONEBIE_TZ'] = 'International Date Line West'
 # Require zonebie before any other gem to ensure it sets the correct test timezone.
+# Setting zonebie to London for travis tests so it matches the .travis.yml ENV.
+ENV['ZONEBIE_TZ'] = 'Europe/London' if ENV['TRAVIS'] == 'true'
 require 'zonebie/rspec'
 
 Bundler.require :default, :development

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -18,6 +18,10 @@ class TwiceDailyTestJob < ::Que::Job
   def run; end
 end
 
+class TimezoneTestJob < ::Que::Job
+  def run; end
+end
+
 class NotAQueJob
   def run; end
 end


### PR DESCRIPTION
The latest version of [fugit](https://github.com/floraison/fugit) will [add support](https://github.com/floraison/fugit/issues/2#issuecomment-376008274) for timezones in cron files.