### PR TITLE
Split the audit table into two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0 (2018-05-02)
+
+* Split the audit table into job execution event and multiple enqueued job rows
+
 ## 2.0.2 (2018-04-29)
 
 * Moved pg gem to development dependencies

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ files, but with additional features.
     ```ruby
     class CreateQueSchedulerSchema < ActiveRecord::Migration
       def change
-        Que::Scheduler::Migrations.migrate!(version: 2)
+        Que::Scheduler::Migrations.migrate!(version: 3)
       end
     end
     ```

--- a/lib/que/scheduler/audit.rb
+++ b/lib/que/scheduler/audit.rb
@@ -4,19 +4,34 @@ module Que
   module Scheduler
     module Audit
       TABLE_NAME = 'que_scheduler_audit'
+      ENQUEUED_TABLE_NAME = 'que_scheduler_audit_enqueued'
       INSERT_AUDIT = %{
-        INSERT INTO #{TABLE_NAME} (scheduler_job_id, jobs_enqueued, executed_at, next_run_at)
-        VALUES ($1::integer, $2::jsonb, $3::timestamptz, $4::timestamptz)
+        INSERT INTO #{TABLE_NAME} (scheduler_job_id, executed_at)
+        VALUES ($1::integer, $2::timestamptz)
+        RETURNING *
+      }
+      INSERT_AUDIT_ENQUEUED = %{
+        INSERT INTO #{ENQUEUED_TABLE_NAME} (scheduler_job_id, job_class, queue, priority, args)
+        VALUES ($1::integer, $2::varchar, $3::varchar, $4::integer, $5::jsonb)
         RETURNING *
       }
 
       class << self
-        def append(job_id, executed_at, result, next_run_at)
-          json = result.missed_jobs.map { |j| j.to_h.merge(job_class: j.job_class.to_s) }.to_json
-          inserted = ::Que.execute(
-            INSERT_AUDIT, [job_id, json, executed_at, next_run_at]
-          )
-          raise "Cannot save audit row #{job_id} #{executed_at}" if inserted.empty?
+        def append(job_id, executed_at, result)
+          ::Que.execute(INSERT_AUDIT, [job_id, executed_at])
+          result.missed_jobs.each do |j|
+            inserted = ::Que.execute(
+              INSERT_AUDIT_ENQUEUED,
+              [
+                job_id,
+                j.job_class,
+                j.queue,
+                j.priority,
+                j.args
+              ]
+            )
+            raise "Cannot save audit row #{job_id} #{executed_at} #{j}" if inserted.empty?
+          end
         end
       end
     end

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -87,18 +87,17 @@ module Que
       end
 
       def generate_to_enqueue_list(missed_times)
-        [].tap do |jobs_for_class|
-          unless missed_times.empty?
-            options = to_h.slice(:args, :queue, :priority, :job_class).compact
+        return [] if missed_times.empty?
 
-            if schedule_type == DefinedJob::SCHEDULE_TYPE_EVERY_EVENT
-              missed_times.each do |time_missed|
-                jobs_for_class << ToEnqueue.new(options.merge(args: [time_missed] + (args || [])))
-              end
-            else
-              jobs_for_class << ToEnqueue.new(options)
-            end
+        options = to_h.slice(:args, :queue, :priority, :job_class).compact
+        args_array = args.is_a?(Array) ? args : Array(args)
+
+        if schedule_type == DefinedJob::SCHEDULE_TYPE_EVERY_EVENT
+          missed_times.map do |time_missed|
+            ToEnqueue.new(options.merge(args: [time_missed] + args_array))
           end
+        else
+          [ToEnqueue.new(options.merge(args: args_array))]
         end
       end
     end

--- a/lib/que/scheduler/migrations/3/down.sql
+++ b/lib/que/scheduler/migrations/3/down.sql
@@ -1,0 +1,8 @@
+DROP TABLE que_scheduler_audit_enqueued;
+ALTER TABLE que_scheduler_audit DROP CONSTRAINT que_scheduler_audit_pkey;
+
+ALTER TABLE que_scheduler_audit
+ADD COLUMN next_run_at      timestamptz,
+ADD COLUMN jobs_enqueued    jsonb;
+
+CREATE INDEX index_que_scheduler_audit_on_jobs_enqueued ON que_scheduler_audit USING btree (jobs_enqueued);

--- a/lib/que/scheduler/migrations/3/up.sql
+++ b/lib/que/scheduler/migrations/3/up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE que_scheduler_audit ADD PRIMARY KEY (scheduler_job_id);
+
+CREATE TABLE que_scheduler_audit_enqueued (
+  scheduler_job_id integer      NOT NULL REFERENCES que_scheduler_audit (scheduler_job_id),
+  job_class        varchar(255) NOT NULL,
+  queue            varchar(255),
+  priority         integer,
+  args             jsonb        NOT NULL
+);
+
+CREATE INDEX que_scheduler_audit_enqueued_job_class ON que_scheduler_audit_enqueued USING btree (job_class);
+CREATE INDEX que_scheduler_audit_enqueued_args ON que_scheduler_audit_enqueued USING btree (args);
+
+WITH rows AS (SELECT scheduler_job_id, json_array_elements(jobs_enqueued::json) AS enqueued FROM que_scheduler_audit)
+INSERT INTO que_scheduler_audit_enqueued(scheduler_job_id, args, job_class)
+SELECT scheduler_job_id, (enqueued->>'args')::json AS args, enqueued->>'job_class' AS job_class FROM rows;
+
+ALTER TABLE que_scheduler_audit DROP COLUMN next_run_at;
+ALTER TABLE que_scheduler_audit DROP COLUMN jobs_enqueued;

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -59,7 +59,7 @@ module Que
           job_dictionary: result.job_dictionary,
           run_at: next_run_at
         )
-        Audit.append(attrs[:job_id], scheduler_job_args.as_time, result, next_run_at)
+        Audit.append(attrs[:job_id], scheduler_job_args.as_time, result)
       end
     end
   end

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = '2.0.2'.freeze
+    VERSION = '2.1.0'.freeze
   end
 end

--- a/spec/config/que_schedule.yml
+++ b/spec/config/que_schedule.yml
@@ -11,10 +11,12 @@ WithArgsTestJob:
 daily_test_job_specifying_class:
   class: SpecifiedByClassTestJob
   cron: "10 3 * * *"
+  args: One arg
   schedule_type: default
 
 DailyTestJob:
   cron: "10 6 * * *"
+  args: Single arg
   schedule_type: every_event
 
 TwiceDailyTestJob:

--- a/spec/que/scheduler/audit_spec.rb
+++ b/spec/que/scheduler/audit_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Que::Scheduler::Audit do
     it 'appends an audit line' do
       job_id = 1234
       executed_at = Time.zone.now.change(usec: 0)
-      next_run_at = (Time.zone.now + 1.hour).change(usec: 0)
       missed_jobs = [
         { job_class: HalfHourlyTestJob, queue: 'some_queue', args: [5] },
         { job_class: HalfHourlyTestJob, priority: 80 },
@@ -14,25 +13,37 @@ RSpec.describe Que::Scheduler::Audit do
       result = Que::Scheduler::EnqueueingCalculator::Result.new(
         missed_jobs: hash_to_enqueues(missed_jobs), job_dictionary: []
       )
-      described_class.append(job_id, executed_at, result, next_run_at)
+      described_class.append(job_id, executed_at, result)
 
       audit = Que.execute('select * from que_scheduler_audit')
       expect(audit.count).to eq(1)
       expect(audit.first['scheduler_job_id']).to eq(job_id)
       expect(audit.first['executed_at']).to eq(executed_at)
-      expect(audit.first['next_run_at']).to eq(next_run_at)
-      db_jobs = JSON.parse(audit.first['jobs_enqueued'])
+      db_jobs = Que.execute('select * from que_scheduler_audit_enqueued')
       expect(db_jobs.count).to eq(3)
-      expect(db_jobs.first).to eq(
-        'job_class' => 'HalfHourlyTestJob',
-        'queue' => 'some_queue',
-        'args' => [5]
-      )
       expect(db_jobs).to eq(
         [
-          { 'job_class' => 'HalfHourlyTestJob', 'queue' => 'some_queue', 'args' => [5] },
-          { 'job_class' => 'HalfHourlyTestJob', 'priority' => 80, 'args' => [] },
-          { 'job_class' => 'DailyTestJob', 'queue' => 'some_queue', 'args' => [3] }
+          {
+            'scheduler_job_id' => 1234,
+            'job_class' => 'HalfHourlyTestJob',
+            'queue' => 'some_queue',
+            'priority' => nil,
+            'args' => '[5]',
+          },
+          {
+            'scheduler_job_id' => 1234,
+            'job_class' => 'HalfHourlyTestJob',
+            'queue' => nil,
+            'priority' => 80,
+            'args' => '[]',
+          },
+          {
+            'scheduler_job_id' => 1234,
+            'job_class' => 'DailyTestJob',
+            'queue' => 'some_queue',
+            'priority' => nil,
+            'args' => '[3]',
+          }
         ]
       )
     end

--- a/spec/que/scheduler/enqueueing_calculator_spec.rb
+++ b/spec/que/scheduler/enqueueing_calculator_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
     run_test(
       '2017-10-08T03:09:59',
       2.seconds,
-      [{ job_class: SpecifiedByClassTestJob }]
+      [{ job_class: SpecifiedByClassTestJob, args: ['One arg'] }]
     )
   end
 
@@ -77,7 +77,7 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
     run_test(
       '2017-10-08T06:09:59',
       2.seconds,
-      [{ job_class: DailyTestJob, args: [Time.zone.parse('2017-10-08T06:10:00')] }]
+      [{ job_class: DailyTestJob, args: [Time.zone.parse('2017-10-08T06:10:00'), 'Single arg'] }]
     )
   end
 
@@ -89,11 +89,11 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
         # These are "missable", so only come up once
         { job_class: HalfHourlyTestJob },
         { job_class: WithArgsTestJob, args: ['My Args', 1234, { 'some_hash' => true }] },
-        { job_class: SpecifiedByClassTestJob },
+        { job_class: SpecifiedByClassTestJob, args: ['One arg'] },
         # These are "every_event", so all their missed schedules are enqueued, with that
         # Time as an argument.
-        { job_class: DailyTestJob, args: [Time.zone.parse('2017-10-08T06:10:00')] },
-        { job_class: DailyTestJob, args: [Time.zone.parse('2017-10-09T06:10:00')] },
+        { job_class: DailyTestJob, args: [Time.zone.parse('2017-10-08T06:10:00'), 'Single arg'] },
+        { job_class: DailyTestJob, args: [Time.zone.parse('2017-10-09T06:10:00'), 'Single arg'] },
         {
           job_class: TwiceDailyTestJob,
           args: [Time.zone.parse('2017-10-08T11:10:00')],

--- a/spec/support/db_support.rb
+++ b/spec/support/db_support.rb
@@ -26,7 +26,7 @@ def setup_db
   Que.mode = :off
   Que.connection = ActiveRecord
   Que.migrate!(version: 3)
-  Que::Scheduler::Migrations.migrate!(version: 2)
+  Que::Scheduler::Migrations.migrate!(version: Que::Scheduler::Migrations::MAX_VERSION)
   Que.execute("set timezone TO '#{::Time.zone.tzinfo.identifier}';")
 end
 


### PR DESCRIPTION
This change adds another migration and splits the audit table into the scheduler event, and the individual jobs that were enqueued. This makes it both easier to read and index, and also offload into a data warehouse.