### PR TITLE
Correct migration json column type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
 services:
 - postgresql
 addons:
-  postgresql: "9.6"
+  # We have seen some json errors on some DBs, so choose the oldest with jsonb.
+  postgresql: "9.4"
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Use more exact json cast when migrating
+
 ## 2.1.0 (2018-05-02)
 
 * Split the audit table into job execution event and multiple enqueued job rows

--- a/lib/que/scheduler/migrations/3/up.sql
+++ b/lib/que/scheduler/migrations/3/up.sql
@@ -13,7 +13,7 @@ CREATE INDEX que_scheduler_audit_enqueued_args ON que_scheduler_audit_enqueued U
 
 WITH rows AS (SELECT scheduler_job_id, json_array_elements(jobs_enqueued::json) AS enqueued FROM que_scheduler_audit)
 INSERT INTO que_scheduler_audit_enqueued(scheduler_job_id, args, job_class)
-SELECT scheduler_job_id, (enqueued->>'args')::json AS args, enqueued->>'job_class' AS job_class FROM rows;
+SELECT scheduler_job_id, (enqueued->>'args')::jsonb AS args, enqueued->>'job_class' AS job_class FROM rows;
 
 ALTER TABLE que_scheduler_audit DROP COLUMN next_run_at;
 ALTER TABLE que_scheduler_audit DROP COLUMN jobs_enqueued;

--- a/spec/que/scheduler/migrations_spec.rb
+++ b/spec/que/scheduler/migrations_spec.rb
@@ -25,9 +25,27 @@ RSpec.describe Que::Scheduler::Migrations do
       described_class.migrate!(version: 2)
       expect(described_class.db_version).to eq(2)
       expect(audit_table_exists?).to be true
+
+      # Add a row to check conversion from schema 2 to schema 3
+      Que.execute(<<-SQL)
+        INSERT INTO que_scheduler_audit
+        VALUES (17, '2017-01-01', '2017-01-02', '[{"args": [1, 2], "job_class": "DailyTestJob"}]');
+      SQL
+
       described_class.migrate!(version: 3)
       expect(described_class.db_version).to eq(3)
       expect(enqueued_rows_exists?).to be true
+
+      # Check the row came through correctly
+      audit = Que.execute('SELECT * FROM que_scheduler_audit')
+      expect(audit.count).to eq(1)
+      expect(audit.first[:scheduler_job_id]).to eq(17)
+      expect(audit.first[:executed_at].to_s).to start_with('2017-01-01 00:00:00')
+      audit = Que.execute('SELECT * FROM que_scheduler_audit_enqueued')
+      expect(audit.count).to eq(1)
+      expect(audit.first[:scheduler_job_id]).to eq(17)
+      expect(audit.first[:job_class]).to eq('DailyTestJob')
+      expect(audit.first[:args].to_s).to eq('[1, 2]')
     end
 
     def audit_table_exists?


### PR DESCRIPTION
It seems some versions of postgres are more picky about exact json column types than others. This change makes it more exact.

This should resolve https://github.com/hlascelles/que-scheduler/issues/13