### PR TITLE
Remove use of ActiveRecord and add tests to prevent reintroduction

### DIFF
--- a/lib/que/scheduler/migrations.rb
+++ b/lib/que/scheduler/migrations.rb
@@ -50,7 +50,10 @@ module Que
         end
 
         def audit_table_exists?
-          ActiveRecord::Base.connection.table_exists?(AUDIT_TABLE_NAME)
+          result = Que.execute(<<-SQL)
+            SELECT * FROM information_schema.tables WHERE table_name = '#{AUDIT_TABLE_NAME}';
+          SQL
+          result.any?
         end
       end
     end

--- a/spec/que/scheduler/db_spec.rb
+++ b/spec/que/scheduler/db_spec.rb
@@ -17,4 +17,22 @@ RSpec.describe Que::Scheduler::Db do
       expect(described_class.now).to eq(:bar)
     end
   end
+
+  # We hvae users running both ActiveRecord and Sequel. We should not refer to either of them in
+  # runtime code.
+  describe 'ORM usage' do
+    def check(str)
+      Dir.glob('lib/**/*').each do |file|
+        expect(File.open(file).grep(/#{str}/)).to be_empty if File.file?(file)
+      end
+    end
+
+    it 'ActiveRecord is not used explicitly' do
+      check('ActiveRecord')
+    end
+
+    it 'Sequel is not used explicitly' do
+      check('Sequel')
+    end
+  end
 end


### PR DESCRIPTION
We have both ActiveRecord and Sequel users, so must not rely on either in runtime code.