### PR TITLE
Use bigint for audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Use bigint for audit logs
+
 ## 2.1.2 (2018-05-18)
 
 * Remove use of ActiveRecord

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ files, but with additional features.
     ```ruby
     class CreateQueSchedulerSchema < ActiveRecord::Migration
       def change
-        Que::Scheduler::Migrations.migrate!(version: 3)
+        Que::Scheduler::Migrations.migrate!(version: 4)
       end
     end
     ```

--- a/lib/que/scheduler/migrations/4/down.sql
+++ b/lib/que/scheduler/migrations/4/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE que_scheduler_audit ALTER COLUMN scheduler_job_id TYPE integer;
+ALTER TABLE que_scheduler_audit_enqueued ALTER COLUMN scheduler_job_id TYPE integer;

--- a/lib/que/scheduler/migrations/4/up.sql
+++ b/lib/que/scheduler/migrations/4/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE que_scheduler_audit ALTER COLUMN scheduler_job_id TYPE bigint;
+ALTER TABLE que_scheduler_audit_enqueued ALTER COLUMN scheduler_job_id TYPE bigint;


### PR DESCRIPTION
The main `que_jobs` table uses `bigint`, so the audit tables should too.