### PR TITLE
Store job_id and run_at in audit table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
-* Use bigint for audit logs
+* Use bigint for audit logs [#22](https://github.com/hlascelles/que-scheduler/pull/22)
+* Store enqueued job_id in the audit table [#23](https://github.com/hlascelles/que-scheduler/pull/23)
+* Store enqueued job run_at time in audit table
+* Store actual DB priority value of enqueued job (ie, default priority value instead of NULL if none provided)
+* Store actual DB queue value of enqueued job (ie, '' instead of NULL if none provided)
 
 ## 2.1.2 (2018-05-18)
 

--- a/lib/que/scheduler/migrations/4/down.sql
+++ b/lib/que/scheduler/migrations/4/down.sql
@@ -1,2 +1,5 @@
 ALTER TABLE que_scheduler_audit ALTER COLUMN scheduler_job_id TYPE integer;
 ALTER TABLE que_scheduler_audit_enqueued ALTER COLUMN scheduler_job_id TYPE integer;
+
+ALTER TABLE que_scheduler_audit_enqueued DROP COLUMN job_id;
+ALTER TABLE que_scheduler_audit_enqueued DROP COLUMN run_at;

--- a/lib/que/scheduler/migrations/4/up.sql
+++ b/lib/que/scheduler/migrations/4/up.sql
@@ -1,2 +1,7 @@
 ALTER TABLE que_scheduler_audit ALTER COLUMN scheduler_job_id TYPE bigint;
 ALTER TABLE que_scheduler_audit_enqueued ALTER COLUMN scheduler_job_id TYPE bigint;
+
+ALTER TABLE que_scheduler_audit_enqueued ADD COLUMN job_id bigint;
+ALTER TABLE que_scheduler_audit_enqueued ADD COLUMN run_at timestamptz;
+
+CREATE INDEX que_scheduler_audit_enqueued_job_id ON que_scheduler_audit_enqueued USING btree (job_id);

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -21,8 +21,10 @@ module Que
           logs = ["que-scheduler last ran at #{scheduler_job_args.last_run_time}."]
 
           result = EnqueueingCalculator.parse(DefinedJob.defined_jobs, scheduler_job_args)
-          enqueue_required_jobs(result, logs)
-          enqueue_self_again(scheduler_job_args, scheduler_job_args.as_time, result)
+          enqueued_jobs = enqueue_required_jobs(result, logs)
+          enqueue_self_again(
+            scheduler_job_args, scheduler_job_args.as_time, result.job_dictionary, enqueued_jobs
+          )
 
           # Only now we're sure nothing errored, log the results
           logs.each { |str| ::Que.log(message: str) }
@@ -31,16 +33,19 @@ module Que
       end
 
       def enqueue_required_jobs(result, logs)
-        result.missed_jobs.each do |to_enqueue|
+        result.missed_jobs.map do |to_enqueue|
           job_class = to_enqueue.job_class
           args = to_enqueue.args
           remaining_hash = to_enqueue.except(:job_class, :args)
-          if args.is_a?(Hash)
-            job_class.enqueue(args.merge(remaining_hash))
-          else
-            job_class.enqueue(*args, remaining_hash)
-          end
-          logs << "que-scheduler enqueueing #{job_class} with: #{to_enqueue}"
+          enqueued_job =
+            if args.is_a?(Hash)
+              job_class.enqueue(args.merge(remaining_hash))
+            else
+              job_class.enqueue(*args, remaining_hash)
+            end
+          job_id = enqueued_job.attrs.fetch('job_id')
+          logs << "que-scheduler enqueueing #{job_class} #{job_id} with: #{to_enqueue}"
+          enqueued_job
         end
       end
 
@@ -52,14 +57,14 @@ module Que
         raise "Only one #{self.class.name} should be enqueued. #{schedulers} were found."
       end
 
-      def enqueue_self_again(scheduler_job_args, last_full_execution, result)
+      def enqueue_self_again(scheduler_job_args, last_full_execution, job_dictionary, enqueued_jobs)
         next_run_at = scheduler_job_args.as_time.beginning_of_minute + SCHEDULER_FREQUENCY
         SchedulerJob.enqueue(
           last_run_time: last_full_execution.iso8601,
-          job_dictionary: result.job_dictionary,
+          job_dictionary: job_dictionary,
           run_at: next_run_at
         )
-        Audit.append(attrs[:job_id], scheduler_job_args.as_time, result)
+        Audit.append(attrs[:job_id], scheduler_job_args.as_time, enqueued_jobs)
       end
     end
   end


### PR DESCRIPTION
This adds two new columns to the audit table. It also now (instead) stores in the audit table the values that resulted from the job being inserted into the DB. That is, taking into account defaults such as default priority and queue.