### PR TITLE
Handling middle overriding enqueue that prevents a job from being enqueued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Handling middle overriding enqueue that prevents a job from being enqueued [#28](https://github.com/hlascelles/que-scheduler/pull/28)
+
 ## 3.0.0 (2018-05-23)
 
 * Use bigint for audit logs [#22](https://github.com/hlascelles/que-scheduler/pull/22)

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'combustion'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'fasterer'
   spec.add_development_dependency 'pg', '~> 0.21'
   spec.add_development_dependency 'pry-byebug'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,15 @@ RSpec.configure do |config|
   end
   config.before(:each) do
     ::Que.clear!
+    expect(Que.execute('select * from que_scheduler_audit').count).to eq(0)
+    expect(Que.execute('select * from que_scheduler_audit_enqueued').count).to eq(0)
   end
   config.before(:suite) do
     setup_db
+  end
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end


### PR DESCRIPTION
Some middlewares could cause an enqueue not to enqueue a job. For example, an equivalent of resque-solo could decide that the enqueue is not necessary and just short circuit. When this happens we don't want to error, but just log the fact.