### PR TITLE
Adding config block and transaction adapter configuration

### DIFF
--- a/.reek
+++ b/.reek
@@ -1,7 +1,8 @@
 ---
 Attribute:
   enabled: true
-  exclude: []
+  exclude:
+  - Que::Scheduler
 BooleanParameter:
   enabled: false
   exclude: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## Unreleased
+## 3.1.0 (2018-06-01)
 
+* Addition of a gem config initializer [#29](https://github.com/hlascelles/que-scheduler/pull/29)
+* Allow configuration of the transaction block adapter [#29](https://github.com/hlascelles/que-scheduler/pull/29)
 * Handling middle overriding enqueue that prevents a job from being enqueued [#28](https://github.com/hlascelles/que-scheduler/pull/28)
 
 ## 3.0.0 (2018-05-23)

--- a/lib/que-scheduler.rb
+++ b/lib/que-scheduler.rb
@@ -1,0 +1,3 @@
+# rubocop:disable Naming/FileName
+require 'que/scheduler'
+# rubocop:enable Naming/FileName

--- a/lib/que/scheduler.rb
+++ b/lib/que/scheduler.rb
@@ -1,4 +1,5 @@
 require 'que/scheduler/version'
+require 'que/scheduler/config'
 require 'que/scheduler/scheduler_job'
 require 'que/scheduler/db'
 require 'que/scheduler/audit'

--- a/lib/que/scheduler/config.rb
+++ b/lib/que/scheduler/config.rb
@@ -1,0 +1,24 @@
+require 'que'
+
+module Que
+  module Scheduler
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configure
+      self.configuration ||= Configuration.new
+      yield(configuration)
+    end
+
+    class Configuration
+      attr_accessor :schedule_location
+      attr_accessor :transaction_adapter
+    end
+  end
+end
+
+Que::Scheduler.configure do |config|
+  config.schedule_location = ENV.fetch('QUE_SCHEDULER_CONFIG_LOCATION', 'config/que_schedule.yml')
+  config.transaction_adapter = ::Que.method(:transaction)
+end

--- a/lib/que/scheduler/db.rb
+++ b/lib/que/scheduler/db.rb
@@ -15,6 +15,10 @@ module Que
         def now
           Que.execute(NOW_SQL).first.values.first
         end
+
+        def transaction
+          Que::Scheduler.configuration.transaction_adapter.call { yield }
+        end
       end
     end
   end

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -6,10 +6,6 @@ require 'backports/2.4.0/hash/compact'
 module Que
   module Scheduler
     class DefinedJob < Hashie::Dash
-      QUE_SCHEDULER_CONFIG_LOCATION =
-        ENV.fetch('QUE_SCHEDULER_CONFIG_LOCATION', 'config/que_schedule.yml')
-      ERROR_MESSAGE_SUFFIX = "in que-scheduler config #{QUE_SCHEDULER_CONFIG_LOCATION}".freeze
-
       include Hashie::Extensions::Dash::PropertyTranslation
 
       SCHEDULE_TYPES = [
@@ -55,7 +51,8 @@ module Que
 
       class << self
         def defined_jobs
-          @defined_jobs ||= YAML.safe_load(IO.read(QUE_SCHEDULER_CONFIG_LOCATION)).map do |k, v|
+          schedule_string = IO.read(Que::Scheduler.configuration.schedule_location)
+          @defined_jobs ||= YAML.safe_load(schedule_string).map do |k, v|
             Que::Scheduler::DefinedJob.new(
               {
                 name: k,
@@ -73,7 +70,8 @@ module Que
         private
 
         def err_field(field, value)
-          raise "Invalid #{field} '#{value}' #{ERROR_MESSAGE_SUFFIX}"
+          schedule = Que::Scheduler.configuration.schedule_location
+          raise "Invalid #{field} '#{value}' in que-scheduler schedule #{schedule}"
         end
       end
 

--- a/lib/que/scheduler/migrations.rb
+++ b/lib/que/scheduler/migrations.rb
@@ -13,7 +13,7 @@ module Que
 
       class << self
         def migrate!(version:)
-          ::Que.transaction do
+          Que::Scheduler::Db.transaction do
             current = db_version
             if current < version
               migrate_up(current, version)

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -15,7 +15,7 @@ module Que
       @priority = 0
 
       def run(options = nil)
-        ::Que.transaction do
+        Que::Scheduler::Db.transaction do
           assert_one_scheduler_job
           scheduler_job_args = SchedulerJobArgs.build(options)
           logs = ["que-scheduler last ran at #{scheduler_job_args.last_run_time}."]

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = '3.0.0'.freeze
+    VERSION = '3.1.0'.freeze
   end
 end

--- a/spec/que/scheduler/db_spec.rb
+++ b/spec/que/scheduler/db_spec.rb
@@ -34,5 +34,10 @@ RSpec.describe Que::Scheduler::Db do
     it 'Sequel is not used explicitly' do
       check('Sequel')
     end
+
+    # Check Que.transaction is not used, as the config transaction proc should be used instead
+    it 'Que.transaction is not used explicitly' do
+      check('Que.transaction')
+    end
   end
 end

--- a/spec/que/scheduler/defined_job_spec.rb
+++ b/spec/que/scheduler/defined_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Que::Scheduler::DefinedJob do
           job_class: 'HalfHourlyTestJob',
           cron: 'foo 17 * * *'
         )
-      end.to raise_error(/Invalid cron 'foo 17 \* \* \*' in que-scheduler config/)
+      end.to raise_error(/Invalid cron 'foo 17 \* \* \*' in que-scheduler schedule/)
     end
 
     it 'allows crons with fugit compatible english words' do
@@ -77,7 +77,7 @@ RSpec.describe Que::Scheduler::DefinedJob do
           job_class: 'HalfHourlyTestJob',
           queue: 3_214_214
         )
-      end.to raise_error(/Invalid queue '3214214' in que-scheduler config/)
+      end.to raise_error(/Invalid queue '3214214' in que-scheduler schedule/)
     end
 
     it 'checks the priority is an integer' do
@@ -87,7 +87,7 @@ RSpec.describe Que::Scheduler::DefinedJob do
           job_class: 'HalfHourlyTestJob',
           priority: 'foo'
         )
-      end.to raise_error(/Invalid priority 'foo' in que-scheduler config/)
+      end.to raise_error(/Invalid priority 'foo' in que-scheduler schedule/)
     end
 
     it 'checks the job_class is a Que::Job from job_class' do
@@ -96,7 +96,7 @@ RSpec.describe Que::Scheduler::DefinedJob do
           name: 'checking_job_types',
           job_class: 'NotAQueJob'
         )
-      end.to raise_error(/Invalid job_class 'NotAQueJob' in que-scheduler config/)
+      end.to raise_error(/Invalid job_class 'NotAQueJob' in que-scheduler schedule/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@ require 'bundler/setup'
 require 'coveralls'
 Coveralls.wear!
 
-ENV['QUE_SCHEDULER_CONFIG_LOCATION'] = "#{__dir__}/config/que_schedule.yml"
-
 # By default, que-scheduler specs run in different timezones with every execution, thanks to
 # zonebie. If you want to force one particular timezone, you can use the following:
 # ENV['ZONEBIE_TZ'] = 'International Date Line West'
@@ -16,6 +14,10 @@ require 'zonebie/rspec'
 Bundler.require :default, :development
 
 Dir["#{__dir__}/../spec/support/**/*.rb"].each { |f| require f }
+
+Que::Scheduler.configure do |config|
+  config.schedule_location = "#{__dir__}/config/que_schedule.yml"
+end
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This change adds a configuration initializer for the gem.

Using the initializer, the user of the gem can specify how they want transactions to be handled, for example using the `ActiveRecord::Base.transaction` call if it is needed.