### PR TITLE
Drop support for ruby 2.1 and rails 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1
 - 2.2
 - 2.3
 - 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Drop support for ruby 2.1 and rails 3.x
+
 ## 3.1.1 (2018-06-05)
 
 * Remove railtie [#30](https://github.com/hlascelles/que-scheduler/pull/30)

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ the root of the project.
 #### Versions 3.x 
   - Addition of a config initializer.
   - Addition of numerous extra columns to the audit table.
+  - Drop support for ruby 2.1 and rails 3.x
   - Required cumulative migration: `Que::Scheduler::Migrations.migrate!(version: 4)`
 #### Versions 2.x 
   - Introduction of the audit table.

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{lib}/**/*'] + ['README.md']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 3.0'
+  spec.add_dependency 'activesupport', '>= 4.0'
   spec.add_dependency 'backports', '~> 3.10'
   spec.add_dependency 'fugit', '~> 1.1'
   spec.add_dependency 'hashie', '~> 3'
   spec.add_dependency 'que', '~> 0.10'
 
-  spec.add_development_dependency 'activerecord', '>= 3.0'
+  spec.add_development_dependency 'activerecord', '>= 4.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'combustion'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
Official support for ruby 2.1 ended [over a year ago](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) and it is causing some extra testing overhead. Also que 1.0 does not support it.

Similarly remove support for rails 3.x, as it [doesn't have](https://github.com/rails/rails/commit/6f380d37788a562c13d0d68b1d3f28f8a6f4b3ec#diff-2242aaf5c2c9f795d8ddb8abb34f85c3R128) some methods we need, added in rails 4.x