### PR TITLE
Do nothing if migrate! is called on a test DB when que-testing is present

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,5 @@ Style/Documentation:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: single_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Do nothing if `migrate!` is called on a test database. [#39](https://github.com/hlascelles/que-scheduler/pull/39)
+
 ## 3.2.1 (2018-07-01)
 
 - Add support for ruby 2.5

--- a/gemfiles/activesupport_4.gemfile.lock
+++ b/gemfiles/activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.1.1)
+    que-scheduler (3.2.1)
       activesupport (>= 4.0)
       backports (~> 3.10)
       fugit (~> 1.1)

--- a/gemfiles/activesupport_5.gemfile.lock
+++ b/gemfiles/activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.1.1)
+    que-scheduler (3.2.1)
       activesupport (>= 4.0)
       backports (~> 3.10)
       fugit (~> 1.1)

--- a/lib/que/scheduler/migrations.rb
+++ b/lib/que/scheduler/migrations.rb
@@ -13,6 +13,9 @@ module Que
 
       class << self
         def migrate!(version:)
+          # Like que, Do not migrate test DBs.
+          return if defined?(Que::Testing)
+
           Que::Scheduler::Db.transaction do
             current = db_version
             if current < version

--- a/spec/que/scheduler/migrations_spec.rb
+++ b/spec/que/scheduler/migrations_spec.rb
@@ -82,5 +82,16 @@ RSpec.describe Que::Scheduler::Migrations do
     def enqueued_table_exists?
       ActiveRecord::Base.connection.table_exists?(Que::Scheduler::Audit::ENQUEUED_TABLE_NAME)
     end
+
+    # When que-testing is present, calls to Que.execute do nothing and return an empty array.
+    # Thus, trying to migrate a test database will always fail. It is safer to do nothing and not
+    # create the que-scheduler tables. This follows the logic of que, which does not create its
+    # tables either.
+    it "does nothing, and doesn't error, when using que-testing" do
+      described_class.migrate!(version: 0)
+      stub_const('Que::Testing', true)
+      described_class.migrate!(version: 4)
+      expect(audit_table_exists?).to be false
+    end
   end
 end


### PR DESCRIPTION
When que-testing is present, calls to Que.execute do nothing and return an empty array. Thus, trying to migrate a test database will always fail. It is safer to do nothing and not create the que-scheduler tables. This follows the logic of que, which does not create its tables either.