### PR TITLE
Provide access to schedule to allow spec phase tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ As of migration `4`, two elements are added to the DB for que-scheduler to run.
   `que_scheduler_audit_enqueued`. The first tracks when the scheduler calculated what was necessary to run 
   (if anything). The second then logs every job that the scheduler enqueues. 
 
+## Testing Configuration
+
+You can add tests to validate your configuration during the spec phase. This will perform a variety 
+of sanity checks and ensure that:
+
+1. The yml is present and valid
+1. The job classes exist and are descendants of Que::Job
+1. The cron fields are present and valid
+1. The queues (if present) are strings
+1. The priorities (if present) are integers
+1. The schedule_types are known
+
+```ruby
+
+  describe 'check que_schedule.yml' do
+    it 'loads the schedule from the default location' do
+      # Will raise an error if any config is invalid
+      expect(Que::Scheduler.schedule).not_to be nil
+    end
+  end
+```
+
+## Error Notification
+
+If there is an error during scheduling, que-scheduler will report it using the [standard que error
+notifier](https://github.com/chanks/que/blob/master/docs/error_handling.md#error-notifications).
+The scheduler will then continue to retry indefinitely.
+
 ## Upgrading
 
 que-scheduler uses [semantic versioning](https://semver.org/), so major version changes will usually 

--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -1,0 +1,51 @@
+require_relative 'defined_job'
+
+module Que
+  module Scheduler
+    class Schedule
+      class << self
+        def schedule
+          @schedule ||=
+            begin
+              location = Que::Scheduler.configuration.schedule_location
+              from_file(location)
+            end
+        end
+
+        def from_file(location)
+          yml = IO.read(location)
+          config_hash = YAML.safe_load(yml)
+          from_hash(config_hash)
+        end
+
+        def from_hash(config_hash)
+          config_hash.map do |name, defined_job_hash|
+            [name, hash_item_to_defined_job(name, defined_job_hash)]
+          end.to_h
+        end
+
+        private
+
+        def hash_item_to_defined_job(name, defined_job_hash)
+          Que::Scheduler::DefinedJob.new(
+            {
+              name: name,
+              job_class: defined_job_hash['class'] || name,
+              queue: defined_job_hash['queue'],
+              args: defined_job_hash['args'],
+              priority: defined_job_hash['priority'],
+              cron: defined_job_hash['cron'],
+              schedule_type: defined_job_hash['schedule_type'],
+            }.compact
+          ).freeze
+        end
+      end
+    end
+
+    class << self
+      def schedule
+        Schedule.schedule
+      end
+    end
+  end
+end

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -1,6 +1,6 @@
 require 'que'
 
-require_relative 'defined_job'
+require_relative 'schedule'
 require_relative 'enqueueing_calculator'
 require_relative 'scheduler_job_args'
 require_relative 'state_checks'
@@ -22,7 +22,7 @@ module Que
           scheduler_job_args = SchedulerJobArgs.build(options)
           logs = ["que-scheduler last ran at #{scheduler_job_args.last_run_time}."]
 
-          result = EnqueueingCalculator.parse(DefinedJob.defined_jobs, scheduler_job_args)
+          result = EnqueueingCalculator.parse(Scheduler.schedule.values, scheduler_job_args)
           enqueued_jobs = enqueue_required_jobs(result, logs)
           enqueue_self_again(
             scheduler_job_args, scheduler_job_args.as_time, result.job_dictionary, enqueued_jobs

--- a/spec/config/que_schedule2.yml
+++ b/spec/config/que_schedule2.yml
@@ -1,0 +1,3 @@
+test_schedule_2:
+  class: HalfHourlyTestJob
+  cron: "1 2 3 4 5"

--- a/spec/que/scheduler/enqueueing_calculator_spec.rb
+++ b/spec/que/scheduler/enqueueing_calculator_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
       job_dictionary: all_keys,
       as_time: as_time
     )
-    out = QSSP.parse(::Que::Scheduler::DefinedJob.defined_jobs, scheduler_job_args)
+    out = QSSP.parse(::Que::Scheduler.schedule.values, scheduler_job_args)
     exp = Que::Scheduler::EnqueueingCalculator::Result.new(
       missed_jobs: hash_to_enqueues(expect_scheduled), job_dictionary: all_keys
     )

--- a/spec/que/scheduler/scheduler_job_spec.rb
+++ b/spec/que/scheduler/scheduler_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Que::Scheduler::SchedulerJob do
   let(:default_queue) { column_default('que_jobs', 'queue').split(':').first[1..-2] }
   let(:default_priority) { column_default('que_jobs', 'priority').to_i }
   let(:run_time) { Time.zone.parse('2017-11-08T13:50:32') }
-  let(:full_dictionary) { ::Que::Scheduler::DefinedJob.defined_jobs.map(&:name) }
+  let(:full_dictionary) { ::Que::Scheduler.schedule.keys }
 
   context 'scheduling' do
     around(:each) do |example|

--- a/spec/que/scheduler/scheduler_spec.rb
+++ b/spec/que/scheduler/scheduler_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Que::Scheduler::Schedule do
+  describe '.schedule' do
+    it 'allows access via ::Que::Scheduler.schedule' do
+      expect(Que::Scheduler::Schedule).to receive(:schedule)
+      Que::Scheduler.schedule
+    end
+
+    it 'loads the test schedule' do
+      expect(Que::Scheduler.schedule.size).to eq(6)
+    end
+  end
+
+  describe '.from_file' do
+    it 'loads the given file' do
+      result = Que::Scheduler::Schedule.from_file('spec/config/que_schedule2.yml')
+      expect(result.size).to eq(1)
+      expect(result.keys.first).to eq('test_schedule_2')
+    end
+  end
+end


### PR DESCRIPTION
This allows programmatic access to the loaded and parsed schedule, which will allow a spec phase check of the configuration.

This will perform a variety of sanity checks and ensure that:

1. The yml is present and valid
1. The job classes exist and are descendants of Que::Job
1. The cron fields are present and valid
1. The queues (if present) are strings
1. The priorities (if present) are integers
1. The schedule_types are known

 ```ruby
   describe 'check que_schedule.yml' do
    it 'loads the schedule from the default location' do
      expect(Que::Scheduler.schedule).not_to be nil
    end
  end