### PR TITLE
Error if self enqueue fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add re-enqueue checks [#76](https://github.com/hlascelles/que-scheduler/pull/76)
+
 ## 3.2.3 (2019-03-06)
 
 - Namespace support modules [#54](https://github.com/hlascelles/que-scheduler/pull/54)

--- a/gemfiles/activesupport_4.gemfile.lock
+++ b/gemfiles/activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.2)
+    que-scheduler (3.2.3)
       activesupport (>= 4.0)
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)

--- a/gemfiles/activesupport_5.gemfile.lock
+++ b/gemfiles/activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.2)
+    que-scheduler (3.2.3)
       activesupport (>= 4.0)
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -65,11 +65,15 @@ module Que
 
       def enqueue_self_again(scheduler_job_args, last_full_execution, job_dictionary, enqueued_jobs)
         next_run_at = scheduler_job_args.as_time.beginning_of_minute + SCHEDULER_FREQUENCY
-        SchedulerJob.enqueue(
+        enqueued_job = SchedulerJob.enqueue(
           last_run_time: last_full_execution.iso8601,
           job_dictionary: job_dictionary,
           run_at: next_run_at
         )
+        unless check_enqueued_job(enqueued_job, SchedulerJob, {}, [])
+          raise 'SchedulerJob could not self-schedule. Has `.enqueue` been monkey patched?'
+        end
+
         Audit.append(attrs[:job_id], scheduler_job_args.as_time, enqueued_jobs)
       end
     end


### PR DESCRIPTION
A que plugin (akin to request-solo) could nix que-scheduler's attempt to reenqueue itself. This must be prevented as the scheduler will cease functioning. This check ensures the enqueue was successful or raises an error to alert the users and retry.