### PR TITLE
Add versioned SQL executor to support Que 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## Unreleased
+
+- Add facade to handle Que.execute differences between versions [#101](https://github.com/hlascelles/que-scheduler/pull/101)
+
 ## 3.2.4 (2019-07-14)
 
 - Add re-enqueue checks [#76](https://github.com/hlascelles/que-scheduler/pull/76)
 - Introduction of initial que 1.0 handling code [#95](https://github.com/hlascelles/que-scheduler/pull/95)
-- Add tests for Que 0.14 [#96](https://github.com/hlascelles/que-scheduler/pull/96)
+- Add tests for Que 0.14 [#97](https://github.com/hlascelles/que-scheduler/pull/97)
 
 ## 3.2.3 (2019-03-06)
 

--- a/lib/que/scheduler/audit.rb
+++ b/lib/que/scheduler/audit.rb
@@ -22,10 +22,10 @@ module Que
 
       class << self
         def append(scheduler_job_id, executed_at, enqueued_jobs)
-          ::Que.execute(INSERT_AUDIT, [scheduler_job_id, executed_at])
+          ::Que::Scheduler::VersionSupport.execute(INSERT_AUDIT, [scheduler_job_id, executed_at])
           enqueued_jobs.each do |j|
             attrs = Que::Scheduler::VersionSupport.job_attributes(j)
-            inserted = ::Que.execute(
+            inserted = ::Que::Scheduler::VersionSupport.execute(
               INSERT_AUDIT_ENQUEUED,
               [scheduler_job_id] +
                 attrs.values_at(:job_class, :queue, :priority, :args, :job_id, :run_at)

--- a/lib/que/scheduler/db.rb
+++ b/lib/que/scheduler/db.rb
@@ -11,11 +11,11 @@ module Que
 
       class << self
         def count_schedulers
-          Que.execute(SCHEDULER_COUNT_SQL).first.values.first.to_i
+          Que::Scheduler::VersionSupport.execute(SCHEDULER_COUNT_SQL).first.values.first.to_i
         end
 
         def now
-          Que.execute(NOW_SQL).first.values.first
+          Que::Scheduler::VersionSupport.execute(NOW_SQL).first.values.first
         end
 
         def transaction

--- a/lib/que/scheduler/version_support.rb
+++ b/lib/que/scheduler/version_support.rb
@@ -13,6 +13,16 @@ module Que
         def job_attributes(enqueued_job)
           enqueued_job.attrs.transform_keys(&:to_sym)
         end
+
+        # Between Que 0.x and 1.x the result of `Que.execute` changed keys from strings to symbols.
+        # Here we wrap the concept and make sure either way produces symbols
+        def execute(str, args = [])
+          normalise_array_of_hashes(Que.execute(str, args))
+        end
+
+        def normalise_array_of_hashes(array)
+          array.map { |row| row.transform_keys(&:to_sym) }
+        end
       end
     end
   end

--- a/spec/que/scheduler/audit_spec.rb
+++ b/spec/que/scheduler/audit_spec.rb
@@ -13,40 +13,41 @@ RSpec.describe Que::Scheduler::Audit do
         ]
         described_class.append(job_id, executed_at, enqueued_jobs)
 
-        audit = Que.execute('select * from que_scheduler_audit')
+        audit = Que::Scheduler::VersionSupport.execute('select * from que_scheduler_audit')
         expect(audit.count).to eq(1)
-        expect(audit.first['scheduler_job_id']).to eq(job_id)
-        expect(audit.first['executed_at']).to eq(executed_at)
-        db_jobs = Que.execute('select * from que_scheduler_audit_enqueued')
+        expect(audit.first[:scheduler_job_id]).to eq(job_id)
+        expect(audit.first[:executed_at]).to eq(executed_at)
+        db_jobs =
+          Que::Scheduler::VersionSupport.execute('select * from que_scheduler_audit_enqueued')
         expect(db_jobs.count).to eq(3)
         expect(db_jobs).to eq(
           [
             {
-              'scheduler_job_id' => 1234,
-              'job_class' => 'HalfHourlyTestJob',
-              'queue' => 'something',
-              'priority' => 100,
-              'args' => '[5]',
-              'job_id' => enqueued_jobs[0].attrs.fetch('job_id'),
-              'run_at' => executed_at - 1.hour,
+              scheduler_job_id: 1234,
+              job_class: 'HalfHourlyTestJob',
+              queue: 'something',
+              priority: 100,
+              args: '[5]',
+              job_id: enqueued_jobs[0].attrs.fetch('job_id'),
+              run_at: executed_at - 1.hour,
             },
             {
-              'scheduler_job_id' => 1234,
-              'job_class' => 'HalfHourlyTestJob',
-              'queue' => '',
-              'priority' => 80,
-              'args' => '[]',
-              'job_id' => enqueued_jobs[1].attrs.fetch('job_id'),
-              'run_at' => executed_at - 2.hours,
+              scheduler_job_id: 1234,
+              job_class: 'HalfHourlyTestJob',
+              queue: '',
+              priority: 80,
+              args: '[]',
+              job_id: enqueued_jobs[1].attrs.fetch('job_id'),
+              run_at: executed_at - 2.hours,
             },
             {
-              'scheduler_job_id' => 1234,
-              'job_class' => 'DailyTestJob',
-              'queue' => 'some_queue',
-              'priority' => 100,
-              'args' => '[3]',
-              'job_id' => enqueued_jobs[2].attrs.fetch('job_id'),
-              'run_at' => executed_at - 3.hours,
+              scheduler_job_id: 1234,
+              job_class: 'DailyTestJob',
+              queue: 'some_queue',
+              priority: 100,
+              args: '[3]',
+              job_id: enqueued_jobs[2].attrs.fetch('job_id'),
+              run_at: executed_at - 3.hours,
             }
           ]
         )

--- a/spec/que/scheduler/db_spec.rb
+++ b/spec/que/scheduler/db_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Que::Scheduler::Db do
 
   describe '.now' do
     it 'returns the time' do
-      expect(Que).to receive(:execute).with(described_class::NOW_SQL).and_return([{ foo: :bar }])
+      expect(Que).to receive(:execute).with(
+        described_class::NOW_SQL, []
+      ).and_return([{ foo: :bar }])
       expect(described_class.now).to eq(:bar)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,8 +36,10 @@ RSpec.configure do |config|
   end
   config.before(:each) do
     ::Que.clear!
-    expect(Que.execute('select * from que_scheduler_audit').count).to eq(0)
-    expect(Que.execute('select * from que_scheduler_audit_enqueued').count).to eq(0)
+    qsa = Que::Scheduler::VersionSupport.execute('select * from que_scheduler_audit')
+    expect(qsa.count).to eq(0)
+    qsae = Que::Scheduler::VersionSupport.execute('select * from que_scheduler_audit_enqueued')
+    expect(qsae.count).to eq(0)
   end
   config.before(:suite) do
     DbSupport.setup_db

--- a/spec/support/db_support.rb
+++ b/spec/support/db_support.rb
@@ -28,19 +28,19 @@ module DbSupport
       Que.migrate!(version: 3)
       Que::Scheduler::Migrations.migrate!(version: Que::Scheduler::Migrations::MAX_VERSION)
       puts "Setting DB timezone to #{::Time.zone.tzinfo.identifier}"
-      Que.execute("set timezone TO '#{::Time.zone.tzinfo.identifier}';")
+      Que::Scheduler::VersionSupport.execute("set timezone TO '#{::Time.zone.tzinfo.identifier}';")
     end
 
     def jobs_by_class(clazz)
-      Que.execute("SELECT * FROM que_jobs where job_class = '#{clazz}'")
+      Que::Scheduler::VersionSupport.execute("SELECT * FROM que_jobs where job_class = '#{clazz}'")
     end
 
     def column_default(table, column_name)
-      Que.execute(%{
+      Que::Scheduler::VersionSupport.execute(%{
         SELECT column_name, column_default
         FROM information_schema.columns
         WHERE (table_schema, table_name, column_name) = ('public', '#{table}', '#{column_name}')
-      }).first.fetch('column_default')
+      }).first.fetch(:column_default)
     end
 
     def mock_db_time_now
@@ -49,10 +49,10 @@ module DbSupport
     end
 
     def scheduler_job_id_type
-      Que.execute(
+      Que::Scheduler::VersionSupport.execute(
         'select column_name, data_type from information_schema.columns ' \
         "where table_name = 'que_scheduler_audit';"
-      ).find { |row| row.fetch('column_name') == 'scheduler_job_id' }.fetch('data_type')
+      ).find { |row| row.fetch(:column_name) == 'scheduler_job_id' }.fetch(:data_type)
     end
 
     def enqueued_table_exists?


### PR DESCRIPTION
Between Que 0.x and 1.x the result of `Que.execute` changed keys from strings to symbols.
Here we wrap the concept and make sure either way produces symbols