### PR TITLE
Add versioned default queue support for 1.0 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add facade to handle Que.execute differences between versions [#101](https://github.com/hlascelles/que-scheduler/pull/101)
+- Add facade to handle default queue differences between versions [#103](https://github.com/hlascelles/que-scheduler/pull/103)
 
 ## 3.2.4 (2019-07-14)
 

--- a/lib/que/scheduler/config.rb
+++ b/lib/que/scheduler/config.rb
@@ -1,4 +1,5 @@
 require 'que'
+require_relative 'version_support'
 
 module Que
   module Scheduler
@@ -14,6 +15,7 @@ module Que
     class Configuration
       attr_accessor :schedule_location
       attr_accessor :transaction_adapter
+      attr_accessor :que_scheduler_queue
     end
   end
 end
@@ -21,4 +23,5 @@ end
 Que::Scheduler.configure do |config|
   config.schedule_location = ENV.fetch('QUE_SCHEDULER_CONFIG_LOCATION', 'config/que_schedule.yml')
   config.transaction_adapter = ::Que.method(:transaction)
+  config.que_scheduler_queue = Que::Scheduler::VersionSupport.default_scheduler_queue
 end

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -72,6 +72,7 @@ module Que
         # And rerun...
         next_run_at = scheduler_job_args.as_time.beginning_of_minute + SCHEDULER_FREQUENCY
         enqueued_job = SchedulerJob.enqueue(
+          queue: Que::Scheduler.configuration.que_scheduler_queue,
           last_run_time: last_full_execution.iso8601,
           job_dictionary: job_dictionary,
           run_at: next_run_at

--- a/lib/que/scheduler/version_support.rb
+++ b/lib/que/scheduler/version_support.rb
@@ -20,6 +20,10 @@ module Que
           normalise_array_of_hashes(Que.execute(str, args))
         end
 
+        def default_scheduler_queue
+          ''
+        end
+
         def normalise_array_of_hashes(array)
           array.map { |row| row.transform_keys(&:to_sym) }
         end

--- a/spec/que/scheduler/audit_spec.rb
+++ b/spec/que/scheduler/audit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Que::Scheduler::Audit do
             {
               scheduler_job_id: 1234,
               job_class: 'HalfHourlyTestJob',
-              queue: '',
+              queue: Que::Scheduler.configuration.que_scheduler_queue,
               priority: 80,
               args: '[]',
               job_id: enqueued_jobs[1].attrs.fetch('job_id'),

--- a/spec/que/scheduler/scheduler_job_spec.rb
+++ b/spec/que/scheduler/scheduler_job_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Que::Scheduler::SchedulerJob do
 
   def expect_itself_enqueued
     hash = expect_one_itself_job
-    expect(hash.fetch(:queue)).to eq('')
+    expect(hash.fetch(:queue)).to eq(Que::Scheduler.configuration.que_scheduler_queue)
     expect(hash.fetch(:priority)).to eq(0)
     expect(hash.fetch(:error_count)).to eq(0)
     expect(hash.fetch(:job_class)).to eq('Que::Scheduler::SchedulerJob')

--- a/spec/que/scheduler/version_support_spec.rb
+++ b/spec/que/scheduler/version_support_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe Que::Scheduler::VersionSupport do
       expect(attrs.fetch(:run_at)).to be_a(Time)
     end
   end
+
+  describe '.default_scheduler_queue' do
+    it 'returns the queue name' do
+      expect(described_class.default_scheduler_queue).to eq('')
+    end
+  end
 end

--- a/spec/support/db_support.rb
+++ b/spec/support/db_support.rb
@@ -16,6 +16,7 @@ module DbSupport
         reconnect: true,
       }
       ActiveRecord::Base.establish_connection(db_config.merge(database: 'postgres'))
+
       conn = ActiveRecord::Base.connection
       if conn.execute("SELECT 1 from pg_database WHERE datname='#{testing_db}';").count > 0
         conn.execute("DROP DATABASE #{testing_db}")


### PR DESCRIPTION
The default Que queue changed between 0.x and 1.x. We must cater for that.