### PR TITLE
Check for synchronous que

### DIFF
--- a/lib/que/scheduler/state_checks.rb
+++ b/lib/que/scheduler/state_checks.rb
@@ -17,9 +17,22 @@ module Que
           db_version = Que::Scheduler::Migrations.db_version
           return if db_version == Que::Scheduler::Migrations::MAX_VERSION
 
+          sync_err =
+            if Que::Scheduler::VersionSupport.running_synchronously? && db_version.zero?
+              code = Que::Scheduler::VersionSupport.running_synchronously_code?
+              <<-ERR_SYNC
+                You currently have Que to run in synchronous mode using
+                #{code}, so it is most likely this error
+                has happened during an initial migration. You should disable synchronous mode and
+                try again. Note, que-scheduler uses "forward time" scheduled jobs, so will not work
+                in synchronous mode.
+
+              ERR_SYNC
+            end
+
           raise(<<-ERR)
             The que-scheduler db migration state was found to be #{db_version}. It should be #{Que::Scheduler::Migrations::MAX_VERSION}.
-
+            #{sync_err}
             que-scheduler adds some tables to the DB to provide an audit history of what was
             enqueued when, and with what options and arguments. The structure of these tables is
             versioned, and should match that version required by the gem.
@@ -42,6 +55,9 @@ module Que
                 Que::Scheduler::Migrations.migrate!(version: #{Que::Scheduler::Migrations::MAX_VERSION})
               end
             end
+
+            It is also possible that you are running a migration with Que set up to execute jobs
+            synchronously. This will fail as que-scheduler needs the above tables to work.
           ERR
         end
 

--- a/lib/que/scheduler/version_support.rb
+++ b/lib/que/scheduler/version_support.rb
@@ -31,11 +31,15 @@ module Que
         end
 
         def default_scheduler_queue
-          if zero_major?
-            ''
-          else
-            Que::DEFAULT_QUEUE
-          end
+          zero_major? ? '' : Que::DEFAULT_QUEUE
+        end
+
+        def running_synchronously?
+          zero_major? ? (Que.mode == :sync) : Que.run_synchronously
+        end
+
+        def running_synchronously_code?
+          zero_major? ? 'Que.mode == :sync' : 'Que.run_synchronously = true'
         end
 
         def zero_major?

--- a/spec/que/scheduler/state_checks_spec.rb
+++ b/spec/que/scheduler/state_checks_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe Que::Scheduler::StateChecks do
       )
     end
   end
+
+  describe '.assert_db_migrated' do
+    {
+      true => :to,
+      false => :not_to,
+    }.each do |k, v|
+      it "detects when running in synchronous mode #{k}" do
+        expect(Que::Scheduler::Migrations).to receive(:db_version).and_return(0)
+        expect(Que::Scheduler::VersionSupport).to receive(:running_synchronously?).and_return(k)
+        expect { described_class.send(:assert_db_migrated) }.to raise_error do |err|
+          expect(err.message).send(v, include('synchronous mode'))
+        end
+      end
+    end
+  end
 end

--- a/spec/que/scheduler/version_support_spec.rb
+++ b/spec/que/scheduler/version_support_spec.rb
@@ -61,4 +61,34 @@ RSpec.describe Que::Scheduler::VersionSupport do
       expect(described_class.default_scheduler_queue).to eq(expected)
     end
   end
+
+  describe '.running_synchronously?' do
+    context 'when true' do
+      before(:each) do
+        if Que::Scheduler::VersionSupport.zero_major?
+          Que.mode = :sync
+        else
+          Que.run_synchronously = true
+        end
+      end
+
+      after(:each) do
+        if Que::Scheduler::VersionSupport.zero_major?
+          Que.mode = :off
+        else
+          Que.run_synchronously = false
+        end
+      end
+
+      it 'returns the value' do
+        expect(described_class.running_synchronously?).to eq(true)
+      end
+    end
+
+    context 'when false' do
+      it 'returns the value' do
+        expect(described_class.running_synchronously?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is to provide better guidance when que is run in [synchronous mode in migrations](https://github.com/hlascelles/que-scheduler/issues/133). 