### PR TITLE
Ensure reliable backoff semantics for Que 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Check for synchronous que [#134](https://github.com/hlascelles/que-scheduler/pull/134)
+- Ensure reliable backoff semantics for Que 1.0 [#135](https://github.com/hlascelles/que-scheduler/pull/135)
+
 ## 3.2.7 (2019-10-19)
 
 - Add support for Que 1.0.0.beta3 [#18](https://github.com/hlascelles/que-scheduler/pull/18)

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -13,8 +13,8 @@ module Que
     class SchedulerJob < Que::Job
       SCHEDULER_FREQUENCY = 60
 
-      # Always highest possible priority.
       Que::Scheduler::VersionSupport.set_priority(self, 0)
+      Que::Scheduler::VersionSupport.apply_retry_semantics(self)
 
       def run(options = nil)
         Que::Scheduler::Db.transaction do


### PR DESCRIPTION
`que-scheduler` must never stop running, so this setting must be applied if Que 1.x is defines the default as anything other than forever. See https://github.com/chanks/que/issues/251.  Covers: https://github.com/hlascelles/que-scheduler/issues/96