### PR TITLE
Que 1.0.0.beta4 compatability

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -28,15 +28,15 @@ end
 
 appraise 'activesupport-4-que-1-x' do
   gem 'activesupport', '~> 4.0'
-  gem 'que', '1.0.0.beta3'
+  gem 'que', '1.0.0.beta4'
 end
 
 appraise 'activesupport-5-que-1-x' do
   gem 'activesupport', '~> 5.0'
-  gem 'que', '1.0.0.beta3'
+  gem 'que', '1.0.0.beta4'
 end
 
 appraise 'activesupport-6-que-1-x' do
   gem 'activesupport', '~> 6.0'
-  gem 'que', '1.0.0.beta3'
+  gem 'que', '1.0.0.beta4'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Check for synchronous que [#134](https://github.com/hlascelles/que-scheduler/pull/134)
 - Ensure reliable backoff semantics for Que 1.0 [#135](https://github.com/hlascelles/que-scheduler/pull/135)
+- Add support for Que 1.0.0.beta4 [#151](https://github.com/hlascelles/que-scheduler/pull/151)
 
 ## 3.2.7 (2019-10-19)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_4_que_0_12.gemfile.lock
+++ b/gemfiles/activesupport_4_que_0_12.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_4_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_4_que_0_14.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_4_que_1_x.gemfile
+++ b/gemfiles/activesupport_4_que_1_x.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 4.0"
-gem "que", "1.0.0.beta3"
+gem "que", "1.0.0.beta4"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_4_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_4_que_1_x.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/
@@ -107,7 +107,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    que (1.0.0.beta3)
+    que (1.0.0.beta4)
     raabro (1.1.6)
     rack (1.6.11)
     rack-test (0.6.3)
@@ -191,7 +191,7 @@ DEPENDENCIES
   fasterer
   pg (~> 0.21)
   pry-byebug
-  que (= 1.0.0.beta3)
+  que (= 1.0.0.beta4)
   que-scheduler!
   rake
   reek (= 5.0.2)

--- a/gemfiles/activesupport_5_que_0_12.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_12.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_5_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_14.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_5_que_1_x.gemfile
+++ b/gemfiles/activesupport_5_que_1_x.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 5.0"
-gem "que", "1.0.0.beta3"
+gem "que", "1.0.0.beta4"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_5_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_5_que_1_x.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/
@@ -106,7 +106,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    que (1.0.0.beta3)
+    que (1.0.0.beta4)
     raabro (1.1.6)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -188,7 +188,7 @@ DEPENDENCIES
   fasterer
   pg (~> 0.21)
   pry-byebug
-  que (= 1.0.0.beta3)
+  que (= 1.0.0.beta4)
   que-scheduler!
   rake
   reek (= 5.0.2)

--- a/gemfiles/activesupport_6_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_6_que_0_14.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activesupport_6_que_1_x.gemfile
+++ b/gemfiles/activesupport_6_que_1_x.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 6.0"
-gem "que", "1.0.0.beta3"
+gem "que", "1.0.0.beta4"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_6_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_6_que_1_x.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
-      que (>= 0.12, <= 1.0.0.beta3)
+      que (>= 0.12, <= 1.0.0.beta4)
 
 GEM
   remote: https://rubygems.org/
@@ -105,7 +105,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    que (1.0.0.beta3)
+    que (1.0.0.beta4)
     raabro (1.1.6)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -188,7 +188,7 @@ DEPENDENCIES
   fasterer
   pg (~> 0.21)
   pry-byebug
-  que (= 1.0.0.beta3)
+  que (= 1.0.0.beta4)
   que-scheduler!
   rake
   reek (= 5.0.2)

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'backports', '~> 3.10'
   spec.add_dependency 'fugit', '~> 1.1', '>= 1.1.8' # 1.1.8 fixes "disallow zero months in cron"
   spec.add_dependency 'hashie', '>= 3', '< 5'
-  spec.add_dependency 'que', '>= 0.12', '<= 1.0.0.beta3'
+  spec.add_dependency 'que', '>= 0.12', '<= 1.0.0.beta4'
 
   spec.add_development_dependency 'activerecord', '>= 4.0'
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
Que was recently bumped to v1.0.0.beta4 to fix an issue found in Rails 6. (Ref: https://github.com/que-rb/que/issues/253)

Bumping `beta3` max requirement to `beta4` so we can use both gems in Rails 6.