### PR TITLE
Remove backports gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##
+
+- Remove backports gem  [#170](https://github.com/hlascelles/que-scheduler/pull/170)
+
 ## 3.3.0 (2020-04-04)
 
 - General bundle update of test gems [#154](https://github.com/hlascelles/que-scheduler/pull/154)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -40,7 +39,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -75,7 +73,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_4_que_0_12.gemfile.lock
+++ b/gemfiles/activesupport_4_que_0_12.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -42,7 +41,6 @@ GEM
       thor (>= 0.14.0)
     arel (6.0.4)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -65,10 +63,10 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -77,7 +75,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_4_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_4_que_0_14.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -42,7 +41,6 @@ GEM
       thor (>= 0.14.0)
     arel (6.0.4)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -65,10 +63,10 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -77,7 +75,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_4_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_4_que_1_x.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -42,7 +41,6 @@ GEM
       thor (>= 0.14.0)
     arel (6.0.4)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -65,10 +63,10 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -77,7 +75,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_0_12.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_12.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -41,7 +40,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -64,10 +62,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -76,7 +74,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_0_12_activejob.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_12_activejob.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -44,7 +43,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -67,10 +65,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
@@ -81,7 +79,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_14.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -41,7 +40,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -64,10 +62,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -76,7 +74,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_0_14_activejob.gemfile.lock
+++ b/gemfiles/activesupport_5_que_0_14_activejob.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -44,7 +43,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -67,10 +65,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
@@ -81,7 +79,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_5_que_1_x.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -41,7 +40,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -64,10 +62,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -76,7 +74,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_5_que_1_x_activejob.gemfile.lock
+++ b/gemfiles/activesupport_5_que_1_x_activejob.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -44,7 +43,6 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -67,10 +65,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
@@ -81,7 +79,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_6_que_0_14.gemfile.lock
+++ b/gemfiles/activesupport_6_que_0_14.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -40,7 +39,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -63,10 +61,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -75,7 +73,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_6_que_0_14_activejob.gemfile.lock
+++ b/gemfiles/activesupport_6_que_0_14_activejob.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -43,7 +42,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -66,10 +64,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
@@ -80,7 +78,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_6_que_1_x.gemfile.lock
+++ b/gemfiles/activesupport_6_que_1_x.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -40,7 +39,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -63,10 +61,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     hashie (4.1.0)
@@ -75,7 +73,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/gemfiles/activesupport_6_que_1_x_activejob.gemfile.lock
+++ b/gemfiles/activesupport_6_que_1_x_activejob.gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (3.2.8)
+    que-scheduler (3.3.0)
       activesupport (>= 4.0)
-      backports (~> 3.10)
       fugit (~> 1.1, >= 1.1.8)
       hashie (>= 3, < 5)
       que (>= 0.12, <= 1.0.0.beta4)
@@ -43,7 +42,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    backports (3.17.0)
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
@@ -66,10 +64,10 @@ GEM
     erubi (1.9.0)
     et-orbi (1.2.4)
       tzinfo
-    fasterer (0.8.2)
+    fasterer (0.8.3)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    fugit (1.3.3)
+    fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
@@ -80,7 +78,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     kwalify (0.7.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -1,6 +1,5 @@
 require 'hashie'
 require 'fugit'
-require 'backports/2.4.0/hash/compact'
 
 # This is the definition of one scheduleable job in the que-scheduler config yml file.
 module Que

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.0'
-  spec.add_dependency 'backports', '~> 3.10'
   spec.add_dependency 'fugit', '~> 1.1', '>= 1.1.8' # 1.1.8 fixes "disallow zero months in cron"
   spec.add_dependency 'hashie', '>= 3', '< 5'
   spec.add_dependency 'que', '>= 0.12', '<= 1.0.0.beta4'


### PR DESCRIPTION
This was only included for `Hash#compact` which is in Ruby 2.4. Given Ruby 2.3 support and below has been dropped, this can now be removed.