### PR TITLE
Drop redundant index

### DIFF
--- a/lib/que/scheduler/migrations/5/down.sql
+++ b/lib/que/scheduler/migrations/5/down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX index_que_scheduler_audit_on_scheduler_job_id ON que_scheduler_audit USING btree (scheduler_job_id);

--- a/lib/que/scheduler/migrations/5/up.sql
+++ b/lib/que/scheduler/migrations/5/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX index_que_scheduler_audit_on_scheduler_job_id;


### PR DESCRIPTION
Hi :wave: 

I have rather small, hobbystic project that uses your gem. I've been checking which tables are the biggest among my project, and noticed this:

```sql

SELECT
-#    relname as "Table",
-#    pg_size_pretty(pg_total_relation_size(relid)) As "Size",
-#    pg_size_pretty(pg_total_relation_size(relid) - pg_relation_size(relid)) as "External Size"
-#    FROM pg_catalog.pg_statio_user_tables ORDER BY pg_total_relation_size(relid) DESC;
┌───────────────────────────────┬─────────┬───────────────┐
│             Table             │  Size   │ External Size │
├───────────────────────────────┼─────────┼───────────────┤
│ que_scheduler_audit           │ 72 MB   │ 36 MB         │
```

For my amount of rows (given how simple single row is)
```sql
select count(*) from que_scheduler_audit;
┌────────┐
│ count  │
├────────┤
│ 846371 │
└────────┘
(1 row)

Time: 67.357 ms
```

I started investigating what exactly takes that much space.

```
 \d que_scheduler_audit;
                       Table "public.que_scheduler_audit"
┌──────────────────┬──────────────────────────┬───────────┬──────────┬─────────┐
│      Column      │           Type           │ Collation │ Nullable │ Default │
├──────────────────┼──────────────────────────┼───────────┼──────────┼─────────┤
│ scheduler_job_id │ bigint                   │           │ not null │         │
│ executed_at      │ timestamp with time zone │           │ not null │         │
└──────────────────┴──────────────────────────┴───────────┴──────────┴─────────┘
Indexes:
    "que_scheduler_audit_pkey" PRIMARY KEY, btree (scheduler_job_id)
    "index_que_scheduler_audit_on_scheduler_job_id" UNIQUE, btree (scheduler_job_id)
Referenced by:
    TABLE "que_scheduler_audit_enqueued" CONSTRAINT "que_scheduler_audit_enqueued_scheduler_job_id_fkey" FOREIGN KEY (scheduler_job_id) REFERENCES que_scheduler_audit(scheduler_job_id)
```

It seems that `que_scheduler_audit` have both `PRIMARY KEY` constraint index AND `UNIQUE` index on the same column, meaning that the latter one is essentially redundant, thus I created a PR that drops it.
After that change, I saved 18MB in my simple application:

```
┌───────────────────────────────┬─────────┬───────────────┐
│             Table             │  Size   │ External Size │
├───────────────────────────────┼─────────┼───────────────┤
│ que_scheduler_audit           │ 54 MB   │ 18 MB         │
```
