### PR TITLE
Fix for job_attributes with indifferent access.

### DIFF
--- a/lib/que/scheduler/version_support.rb
+++ b/lib/que/scheduler/version_support.rb
@@ -33,7 +33,7 @@ module Que
 
         def job_attributes(enqueued_job)
           if zero_major?
-            enqueued_job.attrs.transform_keys(&:to_sym)
+            enqueued_job.attrs.to_h.transform_keys(&:to_sym)
           else
             enqueued_job.que_attrs.transform_keys(&:to_sym).tap do |hash|
               hash[:job_id] = hash.delete(:id)


### PR DESCRIPTION
Hi!

I recently upgraded from v3.2.3 to v3.4.0 with my version of que remaining at v0.14.3 and ran into this issue https://github.com/hlascelles/que-scheduler/issues/175

After doing some digging I discovered that the attrs hash on Que::Job can sometimes have indifferent access as seen below:
https://github.com/que-rb/que/blob/45e68691f2599c13b401e2d70cde6f6fbfcac708/lib/que/railtie.rb#L10

`transform_keys(&:to_sym)` works with no issues, however when this hash is passed to `Hashie::Dash` through 
 creating a new EnqueuedJobType it dies here:
https://github.com/hashie/hashie/blob/b24d6dca2c545637bc3cc3ac4d89f565fc27a9d0/lib/hashie/dash.rb#L199

As looping through the attributes uses the string keys which causes the error on `self[att]`.

This commit will convert the HashWithIndifferentAccess to a standard hash leaving only sym keys at the end of the transform. Whilst being safe to regular hashes.