### PR TITLE
Fix NoMethodError in a non-Rails app

### DIFF
--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -1,4 +1,6 @@
 require "que"
+require "active_support"
+require "active_support/core_ext/time"
 
 require_relative "schedule"
 require_relative "enqueueing_calculator"


### PR DESCRIPTION
Hello. We have an [Hanami API](https://github.com/hanami/api) app that uses Que. Recently we tried to add que-scheduler for running scheduled jobs, but its Que job throws the following error:

```
gems/que-scheduler-3.4.1/lib/que/scheduler/scheduler_job.rb:64:in `enqueue_self_again': undefined method `beginning_of_minute' for 2020-09-14 16:22:59.13245 +0600:Time (NoMethodError)
    from gems/que-scheduler-3.4.1/lib/que/scheduler/scheduler_job.rb:28:in `block in run'
    from gems/que-scheduler-3.4.1/lib/que/scheduler/db.rb:22:in `block in transaction'
    from gems/que-0.14.3/lib/que.rb:174:in `block in transaction'
```

I assume the reason is because que-scheduler code uses ActiveSupport core extensions for Time while they were not properly loaded, which is fine for Rails applications (because Rails loads them anyway) but it is likely to break in a non-Rails app.
## Versions

```
  * que (0.14.3)
  * que-scheduler (3.4.1)
  * activesupport (6.0.3.2)
```