### PR TITLE
Allow programmatically specifying schedule

### DIFF
--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -12,9 +12,18 @@ module Que
             end
         end
 
+        def schedule=(schedule_config)
+          @schedule = from_yaml(schedule_config)
+        end
+
         def from_file(location)
-          yml = IO.read(location)
-          config_hash = YAML.safe_load(yml)
+          from_yaml(IO.read(location))
+        end
+
+        def from_yaml(config)
+          return unless config
+
+          config_hash = YAML.safe_load(config)
           from_hash(config_hash)
         end
 
@@ -61,6 +70,10 @@ module Que
     class << self
       def schedule
         Schedule.schedule
+      end
+
+      def schedule=(value)
+        Schedule.schedule = value
       end
     end
   end

--- a/spec/que/scheduler/schedule_spec.rb
+++ b/spec/que/scheduler/schedule_spec.rb
@@ -14,6 +14,32 @@ RSpec.describe Que::Scheduler::Schedule do
     end
   end
 
+  describe ".schedule=" do
+    let(:new_config_hash) {
+      '
+      SpecifiedByClassTestJob:
+        cron: "02 11 * * *"
+        args:
+          - First
+          - 1234
+          - some_hash: true
+      '
+    }
+
+    it "sets new schedule" do
+      default_schedule = Que::Scheduler.schedule
+
+      Que::Scheduler.schedule = new_config_hash
+      expect(Que::Scheduler.schedule.size).to eq(1)
+      job_config = Que::Scheduler.schedule['SpecifiedByClassTestJob']
+      expect(job_config[:name]).to eq("SpecifiedByClassTestJob")
+      expect(job_config[:args_array]).to eq(["First", 1234, {"some_hash"=>true}])
+
+      Que::Scheduler.schedule = nil
+      expect(Que::Scheduler.schedule).to eq(default_schedule)
+    end
+  end
+
   describe ".from_file" do
     it "loads the given file" do
       result = described_class.from_file("spec/config/que_schedule2.yml")


### PR DESCRIPTION
Some deployments require configuring the schedule via an ENV var at boot time.
This change allows users to overwrite the schedule as needed without having to
write a file to the (possibly read-only) filesystem).