### PR TITLE
Enforce a single scheduler job at the trigger level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Enforce single scheduler job existence at the DB level with triggers and an index [#224](https://github.com/hlascelles/que-scheduler/pull/224)
+
 ## 3.4.3 (2020-10-28)
 
 - Allow programmatically specifying schedule [#220](https://github.com/hlascelles/que-scheduler/pull/220)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ resque-scheduler files, but with additional features.
     ```ruby
     class CreateQueSchedulerSchema < ActiveRecord::Migration
       def change
-        Que::Scheduler::Migrations.migrate!(version: 5)
+        Que::Scheduler::Migrations.migrate!(version: 6)
       end
     end
     ```
@@ -160,8 +160,11 @@ Additionally, there is the audit table `que_scheduler_audit_enqueued`. This logs
 the scheduler enqueues.
 
 When there is a major version (breaking) change, a migration should be run in. The version of the 
-migration proceeds at a faster rate than the version of the gem. To run in all the migrations required
-up to a number, just migrate to that number with one line, and it will perform all the intermediary steps. 
+latest migration proceeds at a faster rate than the version of the gem, eg if the gem is on version
+3 then the migrations may be on version 6). 
+
+To run in all the migrations required up to a number, just migrate to that number with one line, and
+it will perform all the intermediary steps. 
 
 ie, This will perform all migrations necessary up to the latest version, skipping any already 
 performed.
@@ -169,7 +172,7 @@ performed.
 ```ruby
 class CreateQueSchedulerSchema < ActiveRecord::Migration
   def change
-    Que::Scheduler::Migrations.migrate!(version: 5)
+    Que::Scheduler::Migrations.migrate!(version: 6)
   end
 end
 ```
@@ -183,6 +186,7 @@ The changes in past migrations were:
 |    3    | Added the audit table `que_scheduler_audit_enqueued`.                           |
 |    4    | Updated the the audit tables to use bigints                                     |
 |    5    | Dropped an unnecessary index                                                    |
+|    6    | Enforced single scheduler job at the trigger level                              |
 
 ## Built in optional job for audit clear down
 
@@ -214,8 +218,8 @@ in a coherent state with the rest of your database.
 ## Concurrent scheduler detection
 
 No matter how many tasks you have defined in your schedule, you will only ever need one que-scheduler
-job enqueued. que-scheduler knows this, and it will check before performing any operations that 
-there is only one of itself present.
+job enqueued. que-scheduler knows this, and there are DB constraints in place to ensure there is
+only ever exactly one scheduler job.
 
 It also follows que job design [best practices](https://github.com/chanks/que/blob/master/docs/writing_reliable_jobs.md),
 using ACID guarantees, to ensure that it will never run multiple times. If the scheduler crashes for any reason,
@@ -277,9 +281,9 @@ This gem was inspired by the makers of the excellent [Que](https://github.com/ch
 
 ## Contributors
 
+* @bnauta
+* @JackDanger
 * @jish
 * @joehorsnell
-* @bnauta
-* @papodaca
 * @krzyzak
-* @JackDanger
+* @papodaca

--- a/appraisal.sh
+++ b/appraisal.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 echo "Start a docker container with: docker run -p 5430:5432 postgres:9.5.0 then run this script."
-DB_PORT=5430 DB_PASSWORD=postgres bundle exec appraisal rake spec
+DB_PORT=5430 DB_PASSWORD=postgres bundle exec appraisal rspec $@

--- a/lib/que/scheduler/migrations/6/down.sql
+++ b/lib/que/scheduler/migrations/6/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER que_scheduler_prevent_job_deletion_trigger ON que_jobs;
+
+DROP FUNCTION que_scheduler_prevent_job_deletion();
+
+DROP FUNCTION que_scheduler_check_job_exists();
+
+DROP INDEX que_scheduler_job_in_que_jobs_unique_index;

--- a/lib/que/scheduler/migrations/6/up.sql
+++ b/lib/que/scheduler/migrations/6/up.sql
@@ -1,0 +1,26 @@
+-- Ensure there is no more than one scheduler
+CREATE UNIQUE INDEX que_scheduler_job_in_que_jobs_unique_index ON que_jobs(job_class)
+WHERE job_class = 'Que::Scheduler::SchedulerJob';
+
+-- Ensure there is at least one scheduler
+CREATE OR REPLACE FUNCTION que_scheduler_check_job_exists() RETURNS bool AS $$
+SELECT EXISTS(SELECT * FROM que_jobs WHERE job_class = 'Que::Scheduler::SchedulerJob');
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION que_scheduler_prevent_job_deletion() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+BEGIN
+    IF OLD.job_class = 'Que::Scheduler::SchedulerJob' THEN
+        IF NOT que_scheduler_check_job_exists() THEN
+            raise exception 'Deletion of que_scheduler job % prevented. Deleting the que_scheduler job is almost certainly a mistake.', OLD.job_id;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+CREATE CONSTRAINT TRIGGER que_scheduler_prevent_job_deletion_trigger AFTER UPDATE OR DELETE ON que_jobs
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE PROCEDURE que_scheduler_prevent_job_deletion();

--- a/lib/que/scheduler/state_checks.rb
+++ b/lib/que/scheduler/state_checks.rb
@@ -8,7 +8,6 @@ module Que
       class << self
         def check
           assert_db_migrated
-          assert_one_scheduler_job
         end
 
         private
@@ -58,21 +57,6 @@ module Que
 
             It is also possible that you are running a migration with Que set up to execute jobs
             synchronously. This will fail as que-scheduler needs the above tables to work.
-          ERR
-        end
-
-        def assert_one_scheduler_job
-          schedulers = Que::Scheduler::Db.count_schedulers
-          return if schedulers == 1
-
-          raise(<<-ERR)
-            Only one #{Que::Scheduler::SchedulerJob.name} should be enqueued. #{schedulers} were found.
-
-            que-scheduler works by running a self-enqueueing version of itself that determines which
-            jobs should be enqueued based on the provided config. If two or more que-schedulers were
-            to run at once, then duplicate jobs would occur.
-
-            To resolve this problem, please remove any duplicate scheduler jobs from the que_jobs table.
           ERR
         end
       end

--- a/spec/que/scheduler/db_spec.rb
+++ b/spec/que/scheduler/db_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Que::Scheduler::Db do
       expect(described_class.count_schedulers).to eq(0)
       ::Que::Scheduler::SchedulerJob.enqueue
       expect(described_class.count_schedulers).to eq(1)
-      ::Que::Scheduler::SchedulerJob.enqueue
-      expect(described_class.count_schedulers).to eq(2)
     end
   end
 

--- a/spec/que/scheduler/scheduler_job_spec.rb
+++ b/spec/que/scheduler/scheduler_job_spec.rb
@@ -57,13 +57,9 @@ RSpec.describe Que::Scheduler::SchedulerJob do
       it "errors when the enqueue call does not enqueue the #{described_class} job" do
         job = described_class.enqueue
         expect(described_class).to receive(:enqueue).and_return(false)
-        expect_any_instance_of(::Que::Job).to receive(:handle_error).once.and_call_original
-        DbSupport.work_job(job)
-
-        # The job will have been re-enqueued, not by itself during normal operation, but by the
-        # standard que job error retry semantics.
-        hash = expect_one_itself_job
-        expect(hash.fetch(:error_count)).to eq(1)
+        expect {
+          job.run(nil)
+        }.to raise_error(/SchedulerJob could not self-schedule. Has `.enqueue` been monkey patched/)
       end
 
       def run_test(initial_job_args, to_be_scheduled)

--- a/spec/que/scheduler/state_checks_spec.rb
+++ b/spec/que/scheduler/state_checks_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Que::Scheduler::StateChecks do
     end
 
     it "detects when multiple scheduler jobs are enqueued" do
-      2.times { Que::Scheduler::SchedulerJob.enqueue }
-      expect { described_class.check }.to raise_error(
-        /Only one Que::Scheduler::SchedulerJob should be enqueued. 2 were found./
+      Que::Scheduler::SchedulerJob.enqueue # First one is OK
+      expect { Que::Scheduler::SchedulerJob.enqueue }.to raise_error(
+        /#{Regexp.quote("Key (job_class)=(Que::Scheduler::SchedulerJob) already exists")}/
       )
     end
   end


### PR DESCRIPTION
This adds an index and a trigger to checks that there is only ever exactly one que scheduler job in the que_jobs table. This was enforce before in ruby code, but that could be accidentally bypassed by an SQL statement.

It will ensure at the DB level, using triggers, that once the scheduler is started it can't be accidentally deleted. Also it will ensure that not more than one scheduler can be enqueued at once. This has all been enforced before using ruby, but the DB is even more exacting.