### PR TITLE
Add method to reenqueue scheduler in squashed migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add method to reenqueue scheduler in squashed migrations [#226](https://github.com/hlascelles/que-scheduler/pull/226)
+
 ## 4.0.1 (2020-11-29)
 
 - Move setting schedule hash directly to config block [#225](https://github.com/hlascelles/que-scheduler/pull/225)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ The changes in past migrations were:
 |    5    | Dropped an unnecessary index                                                    |
 |    6    | Enforced single scheduler job at the trigger level                              |
 
+The changes to the DB ([DDL](https://en.wikipedia.org/wiki/Data_definition_language)) are all 
+captured in the structure.sql so will be re-run in correctly if squashed - except for the actual 
+scheduling of the job itself (as that is [DML](https://en.wikipedia.org/wiki/Data_manipulation_language)).
+If you squash your migrations make sure this is added as the final line:
+
+```ruby
+Que::Scheduler::Migrations.reenqueue_scheduler_if_missing
+```
+
 ## HA Redundancy and DB restores
 
 Because of the way que-scheduler works, it requires no additional processes. It is, itself, a Que job.

--- a/lib/que/scheduler/migrations.rb
+++ b/lib/que/scheduler/migrations.rb
@@ -41,6 +41,11 @@ module Que
           result.any?
         end
 
+        # This method is only intended for use in squashed migrations
+        def reenqueue_scheduler_if_missing
+          Que::Scheduler::SchedulerJob.enqueue if Que::Scheduler::Db.count_schedulers.zero?
+        end
+
         private
 
         def migrate_up(current, version)

--- a/spec/que/scheduler/migrations_spec.rb
+++ b/spec/que/scheduler/migrations_spec.rb
@@ -135,6 +135,16 @@ RSpec.describe Que::Scheduler::Migrations do
     end
   end
 
+  describe ".reenqueue_scheduler_if_missing" do
+    it "reenqueues if missing" do
+      expect(Que::Scheduler::Db.count_schedulers).to be_zero
+      described_class.reenqueue_scheduler_if_missing
+      expect(Que::Scheduler::Db.count_schedulers).to eq(1)
+      described_class.reenqueue_scheduler_if_missing
+      expect(Que::Scheduler::Db.count_schedulers).to eq(1)
+    end
+  end
+
   describe "DB health" do
     it "has no duplicate indices" do
       # From https://wiki.postgresql.org/wiki/Index_Maintenance


### PR DESCRIPTION
This adds a method to reenqueue scheduler in squashed migrations.

```ruby
Que::Scheduler::Migrations.reenqueue_scheduler_if_missing
```