### PR TITLE
Handle multiple key types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Handle multiple key types [#237](https://github.com/hlascelles/que-scheduler/pull/237)
 - Remove Postgres 9.4 support [#238](https://github.com/hlascelles/que-scheduler/pull/238)
 - Upgrade Rubocop to 1.x and remove Ruby 2.4 support [#239](https://github.com/hlascelles/que-scheduler/pull/239)
 

--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -37,7 +37,8 @@ module Que
 
         def from_hash(config_hash)
           config_hash.map do |name, defined_job_hash|
-            [name, hash_item_to_defined_job(name, defined_job_hash)]
+            name_str = name.to_s
+            [name_str, hash_item_to_defined_job(name_str, defined_job_hash)]
           end.to_h
         end
 
@@ -65,7 +66,7 @@ module Que
 
           Que::Scheduler::DefinedJob.create(
             name: name,
-            job_class: defined_job_hash["class"] || name,
+            job_class: defined_job_hash["class"]&.to_s || name,
             queue: defined_job_hash["queue"],
             args_array: args_array,
             priority: defined_job_hash["priority"],

--- a/spec/que/scheduler/schedule_spec.rb
+++ b/spec/que/scheduler/schedule_spec.rb
@@ -42,6 +42,37 @@ RSpec.describe Que::Scheduler::Schedule do
       expect(job_config[:args_array]).to eq(["First", 1234, { "some_hash" => true }])
     end
 
+    it "loads the schedule with all key types" do
+      Que::Scheduler.configure do |config|
+        config.schedule = {
+          # Symbol
+          AsSymbolSpecifiedByClassTestJob: {
+            class: :SpecifiedByClassTestJob,
+            cron: "01 * * * *",
+          },
+          # String
+          "AsStringSpecifiedByClassTestJob" => {
+            class: "SpecifiedByClassTestJob",
+            cron: "02 * * * *",
+          },
+          # Class
+          SpecifiedByClassTestJob => {
+            cron: "03 * * * *",
+          },
+        }
+      end
+      expect(Que::Scheduler.schedule.keys).to eq(
+        %w[
+          AsSymbolSpecifiedByClassTestJob
+          AsStringSpecifiedByClassTestJob
+          SpecifiedByClassTestJob
+        ]
+      )
+      expect(Que::Scheduler.schedule.values.map(&:job_class)).to eq(
+        [SpecifiedByClassTestJob, SpecifiedByClassTestJob, SpecifiedByClassTestJob]
+      )
+    end
+
     it "errors if the schedule hash is not set and the file is not present" do
       Que::Scheduler.configure do |config|
         config.schedule_location = "spec/config/not_here.yml"


### PR DESCRIPTION
This change ensures that if the config is specified with Strings, Symbols or Classes, then they can all be handled.