### PR TITLE
Remove Postgres 9.4 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # To run this locally:
 # - Download the runner: https://docs.gitlab.com/runner/install/bleeding-edge.html#download-the-standalone-binaries
-# - gitlab-runner-linux-amd64 exec docker "ruby_2_6_postgres_9_4"
+# - gitlab-runner-linux-amd64 exec docker "ruby_2_6_postgres_9_5"
 
 variables:
   BUNDLE_PATH: vendor/bundle
@@ -25,7 +25,6 @@ before_script:
 stages:
 - install
 - quality
-- test_postgres_9_4
 - test_postgres_9_5
 
 .retries: &retries
@@ -50,11 +49,6 @@ stages:
   cache:
     key: ruby_2_6
     <<: *cache_paths
-
-.postgres_9_4: &postgres_9_4
-  stage: test_postgres_9_4
-  services:
-  - postgres:9.4.0
 
 .postgres_9_5: &postgres_9_5
   stage: test_postgres_9_5
@@ -83,16 +77,6 @@ quality:
   stage: quality
   script:
   - "./quality.sh"
-
-ruby_2_5_postgres_9_4:
-  <<: *test
-  <<: *ruby_2_5
-  <<: *postgres_9_4
-
-ruby_2_6_postgres_9_4:
-  <<: *test
-  <<: *ruby_2_6
-  <<: *postgres_9_4
 
 ruby_2_5_postgres_9_5:
   <<: *test

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ A full changelog can be found here: [CHANGELOG.md](https://github.com/hlascelles
 
 ## System requirements
 
-Your [postgres](https://www.postgresql.org/) database must be at least version 9.4.0.
+Your [postgres](https://www.postgresql.org/) database must be at least version 9.5.0.
 
 ## Inspiration
 

--- a/spec/support/db_support.rb
+++ b/spec/support/db_support.rb
@@ -26,8 +26,6 @@ module DbSupport
       ActiveRecord::Base.establish_connection(db_config)
       Que.connection = ActiveRecord
 
-      avoid_invalid_testing_scenarios
-
       # First migrate Que
       Que.migrate!(version: ::Que::Migrations::CURRENT_VERSION)
 
@@ -83,18 +81,6 @@ module DbSupport
       else
         ::Que.run_job_middleware(job) { job.tap(&:_run) }
       end
-    end
-
-    private
-
-    def avoid_invalid_testing_scenarios
-      pg_version = Que::Scheduler::VersionSupport.execute("SELECT version()").first.fetch(:version)
-      return unless pg_version.start_with?("PostgreSQL 9.4") &&
-                    !Que::Scheduler::VersionSupport.zero_major?
-
-      puts "For Postgres 9.4 we cannot test que 1.x (as it uses new jsonb features), " \
-           "so we must short circuit here so the CI build for other versions continues..."
-      exit(0) # Exit 0 for CI
     end
   end
 end


### PR DESCRIPTION
Postgres [9.4](https://www.postgresql.org/support/versioning/) is no longer supported, and it was hard to support and test as Que 1.x did not support it.