### PR TITLE
Add audit cleardown job args tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Check for row count option using String and Symbols [#236](https://github.com/hlascelles/que-scheduler/pull/236)
 - Handle multiple key types [#237](https://github.com/hlascelles/que-scheduler/pull/237)
 - Remove Postgres 9.4 support [#238](https://github.com/hlascelles/que-scheduler/pull/238)
 - Upgrade Rubocop to 1.x and remove Ruby 2.4 support [#239](https://github.com/hlascelles/que-scheduler/pull/239)

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ This gem was inspired by the makers of the excellent [Que](https://github.com/ch
 ## Contributors
 
 * @bnauta
+* @bjeanes
 * @JackDanger
 * @jish
 * @joehorsnell

--- a/lib/que/scheduler/jobs/que_scheduler_audit_clear_down_job.rb
+++ b/lib/que/scheduler/jobs/que_scheduler_audit_clear_down_job.rb
@@ -28,7 +28,7 @@ module Que
         Que::Scheduler::VersionSupport.set_priority(self, 100)
 
         def run(options)
-          retain_row_count = options.fetch(:retain_row_count) { options.fetch("retain_row_count") }
+          retain_row_count = options.symbolize_keys.fetch(:retain_row_count)
           Que::Scheduler::Db.transaction do
             # This may delete zero or more than `retain_row_count` depending on if anything was
             # scheduled in each of the past schedule runs

--- a/spec/integration/integration_test_wrapper_spec.rb
+++ b/spec/integration/integration_test_wrapper_spec.rb
@@ -16,5 +16,11 @@ RSpec.describe "integration tests" do
       "QUE_VERSION=#{Que::Scheduler::VersionSupport.que_version} ruby simple_test.rb"
     )
   end
+
+  it "enqueues and runs the QueSchedulerAuditClearDownJob" do
+    run_integration_test(
+      "QUE_VERSION=#{Que::Scheduler::VersionSupport.que_version} ruby cleardown_job_test.rb"
+    )
+  end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/integration/no_rails/cleardown_job_test.rb
+++ b/spec/integration/no_rails/cleardown_job_test.rb
@@ -1,0 +1,28 @@
+require_relative "integration_setup"
+
+# This test is primarily to check that the que job that the gem provides can run successfully under
+# all Que versions. Specifically since it reads the args during the run method, and they change
+# format between Que 0.x and 1.x.
+
+IntegrationSetup.setup_db
+
+# que-scheduler setup
+Que::Scheduler.configure do |config|
+  config.schedule = {
+    TestQueSchedulerAuditClearDownJob: {
+      cron: "* * * * *",
+      class: Que::Scheduler::Jobs::QueSchedulerAuditClearDownJob,
+      args: {
+        retain_row_count: 0,
+      },
+    },
+  }
+  config.time_zone = "Europe/London"
+end
+
+IntegrationSetup.trigger_scheduler
+
+# Now "run that job that was scheduled"
+IntegrationSetup.run_a_job
+
+puts "Success"

--- a/spec/que/scheduler/jobs/que_scheduler_audit_clear_down_job_spec.rb
+++ b/spec/que/scheduler/jobs/que_scheduler_audit_clear_down_job_spec.rb
@@ -47,5 +47,23 @@ RSpec.describe Que::Scheduler::Jobs::QueSchedulerAuditClearDownJob do
         described_class.run(retain_row_count: 2)
       }.not_to raise_error
     end
+
+    context "when handling both string and symbol run args (ie Que 0.x and 1.x)" do
+      def set_up_expects
+        allow(Que::Scheduler::VersionSupport).to receive(:execute).and_call_original
+        expect(Que::Scheduler::VersionSupport)
+          .to receive(:execute).with(described_class::DELETE_AUDIT_SQL, [1]).and_call_original
+      end
+
+      it "runs with a string" do
+        set_up_expects
+        described_class.run("retain_row_count" => 1)
+      end
+
+      it "runs with a symbol" do
+        set_up_expects
+        described_class.run(retain_row_count: 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds an integration test and spec test to make sure that the args of the QueSchedulerAuditClearDownJob can handle Que 0.x and 1.x args.