### PR TITLE
Remove Ruby 2.5 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,13 +38,6 @@ stages:
     - unknown_failure
     - api_failure
 
-.ruby_2_5: &ruby_2_5
-  <<: *retries
-  image: ruby:2.5
-  cache:
-    key: ruby_2_5
-    <<: *cache_paths
-
 .ruby_2_6: &ruby_2_6
   <<: *retries
   image: ruby:2.6
@@ -73,10 +66,6 @@ stages:
   script:
   - echo "Gems installed..."
 
-install_ruby_2_5:
-  <<: *install
-  <<: *ruby_2_5
-
 install_ruby_2_6:
   <<: *install
   <<: *ruby_2_6
@@ -86,15 +75,10 @@ install_ruby_2_7:
   <<: *ruby_2_7
 
 quality:
-  <<: *ruby_2_5
+  <<: *ruby_2_6
   stage: quality
   script:
   - "./quality.sh"
-
-ruby_2_5_postgres_9_5:
-  <<: *test
-  <<: *ruby_2_5
-  <<: *postgres_9_5
 
 ruby_2_6_postgres_9_5:
   <<: *test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 # - rubocop-rake # Not supported by CodeClimate
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   DisplayCopNames: true
   NewCops: enable
   SuggestExtensions: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Remove support for Ruby 2.5 [#281](https://github.com/hlascelles/que-scheduler/pull/281)
 - Add tests for Ruby 2.7 [#272](https://github.com/hlascelles/que-scheduler/pull/272)
 
 ## 4.1.0 (2021-01-31)

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -1,3 +1,4 @@
+# rubocop:disable Gemspec/RequiredRubyVersion 2.5 may work, but is unsupported
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "que/scheduler/version"
@@ -23,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{lib}/**/*"] + ["README.md"]
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "fugit", "~> 1.1", ">= 1.1.8" # 1.1.8 fixes "disallow zero months in cron"
@@ -49,3 +49,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "zonebie"
   # rubocop:enable Layout/HashAlignment
 end
+# rubocop:enable Gemspec/RequiredRubyVersion


### PR DESCRIPTION
Ruby 2.5 support ended in March 2021. In particular, the globalid gem just [removed support](https://github.com/rails/globalid/commit/4ed45f5b47e2aac33a075f3645c2028ae4735899#diff-83a1d53779ed5d1c639c5c8deddff3a7a0c1a6cef2d1389cdf36728fbaedfcdc) for it too, which breaks unpinned bundle updates.