### PR TITLE
Check ActiveJob is defined

### DIFF
--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -86,7 +86,7 @@ module Que
         # queue name is only supported for a subrange of ActiveJob versions. Print this out as a
         # warning.
         if queue &&
-           Que::Scheduler::ToEnqueue.active_job_loaded? &&
+           Que::Scheduler::ToEnqueue.active_job_defined? &&
            job_class < ::ActiveJob::Base &&
            Que::Scheduler::ToEnqueue.active_job_version < Gem::Version.create("6.0.3")
           puts <<~ERR

--- a/lib/que/scheduler/to_enqueue.rb
+++ b/lib/que/scheduler/to_enqueue.rb
@@ -22,8 +22,8 @@ module Que
           type_from_job_class(job_class).present?
         end
 
-        def active_job_loaded?
-          !!active_job_version
+        def active_job_defined?
+          Object.const_defined?("ActiveJob")
         end
 
         def active_job_version
@@ -54,7 +54,7 @@ module Que
               hash = {
                 ::Que::Job => QueJobType,
               }
-              hash[::ActiveJob::Base] = ActiveJobType if ToEnqueue.active_job_loaded?
+              hash[::ActiveJob::Base] = ActiveJobType if ToEnqueue.active_job_defined?
               hash
             end
         end

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -13,7 +13,7 @@ ALL_TEST_JOB_NAMES = %w[
 
 ALL_TEST_JOB_NAMES.each do |name|
   clazz =
-    if Que::Scheduler::ToEnqueue.active_job_loaded?
+    if Que::Scheduler::ToEnqueue.active_job_defined?
 
       Class.new(::ActiveJob::Base) do
         self.queue_adapter = :que

--- a/spec/support/to_enqueue_test_support.rb
+++ b/spec/support/to_enqueue_test_support.rb
@@ -1,5 +1,5 @@
 shared_context "when job testing" do
-  if Que::Scheduler::ToEnqueue.active_job_loaded?
+  if Que::Scheduler::ToEnqueue.active_job_defined?
     let(:handles_queue_name) {
       Que::Scheduler::ToEnqueue.active_job_version_supports_queues?
     }


### PR DESCRIPTION
Correspond to https://github.com/hlascelles/que-scheduler/issues/309

When ActiveJob is loaded but not defined, It does not use ActiveJob.