### PR TITLE
Ensure migration error message is reported correctly under new versions of Que

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Ensure migration error message is reported correctly under new versions of Que [#316](https://github.com/hlascelles/que-scheduler/pull/316)
+
 ## 4.2.1 (2022-02-02)
 
 - Add support for que 1.0.0 [#308](https://github.com/hlascelles/que-scheduler/pull/308)

--- a/lib/que/scheduler/migrations/6/up.sql
+++ b/lib/que/scheduler/migrations/6/up.sql
@@ -13,7 +13,7 @@ DECLARE
 BEGIN
     IF OLD.job_class = 'Que::Scheduler::SchedulerJob' THEN
         IF NOT que_scheduler_check_job_exists() THEN
-            raise exception 'Deletion of que_scheduler job % prevented. Deleting the que_scheduler job is almost certainly a mistake.', OLD.job_id;
+            raise exception 'Deletion of que_scheduler job prevented. Deleting the que_scheduler job is almost certainly a mistake.';
         END IF;
     END IF;
     RETURN OLD;

--- a/spec/que/scheduler/migrations_spec.rb
+++ b/spec/que/scheduler/migrations_spec.rb
@@ -145,6 +145,16 @@ RSpec.describe Que::Scheduler::Migrations do
     end
   end
 
+  describe "6 up" do
+    it "errors correctly if the scheduler job is deleted" do
+      ::Que::Scheduler::SchedulerJob.enqueue
+      Que::Scheduler::VersionSupport.execute("DELETE FROM que_jobs")
+      expect {
+        Que::Scheduler::VersionSupport.execute("COMMIT")
+      }.to raise_error(/Deletion of que_scheduler job prevented/)
+    end
+  end
+
   describe "DB health" do
     it "has no duplicate indices" do
       # From https://wiki.postgresql.org/wiki/Index_Maintenance


### PR DESCRIPTION
The column name changed in Que 1.x