### PR TITLE
Readd support for ruby 2.5

### DIFF
--- a/.github/workflows/specs.yaml
+++ b/.github/workflows/specs.yaml
@@ -8,7 +8,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [ubuntu]
-         ruby: [2.6, 2.7]
+         ruby: [2.5, 2.6, 2.7]
     services:
       postgres:
         image: postgres:9.5

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ A full changelog can be found here: [CHANGELOG.md](https://github.com/hlascelles
 
 Your [postgres](https://www.postgresql.org/) database must be at least version 9.5.0.
 
+Ruby 2.6 and above is supported. Ruby 2.5 currently still works.
+
 ## Inspiration
 
 This gem was inspired by the makers of the excellent [Que](https://github.com/chanks/que) job scheduler gem. 

--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -39,7 +39,6 @@ module Que
           config_hash
             .map { |name, defined_job_hash|  hash_item_to_defined_job(name.to_s, defined_job_hash) }
             .index_by(&:name)
-          end
         end
 
         def hash_item_to_defined_job(name, defined_job_hash_in)

--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -36,9 +36,9 @@ module Que
         end
 
         def from_hash(config_hash)
-          config_hash.to_h do |name, defined_job_hash|
-            name_str = name.to_s
-            [name_str, hash_item_to_defined_job(name_str, defined_job_hash)]
+          config_hash
+            .map { |name, defined_job_hash|  hash_item_to_defined_job(name.to_s, defined_job_hash) }
+            .index_by(&:name)
           end
         end
 


### PR DESCRIPTION
This PR readds support for ruby 2.5.

The specific change needed was to remove use of `to_h` block syntax which was introduced in ruby 2.6.