### PR TITLE
Add better test coverage and backport from_hash method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add 2.5 functionality and more tests [#320](https://github.com/hlascelles/que-scheduler/pull/320)
 - Add support for Ruby 3.0 [#317](https://github.com/hlascelles/que-scheduler/pull/317)
 - Ensure migration error message is reported correctly under new versions of Que [#316](https://github.com/hlascelles/que-scheduler/pull/316)
 - Check ActiveJob is defined [#315](https://github.com/hlascelles/que-scheduler/pull/315)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,13 @@ A full changelog can be found here: [CHANGELOG.md](https://github.com/hlascelles
 
 Your [postgres](https://www.postgresql.org/) database must be at least version 9.5.0.
 
+Ruby 2.6 and above is supported. Ruby 2.5 currently still currently works but is unsupported.
+
+Using que 0.x with Rails 6 needs a patch to support it. 
+See the patch and how to use it here: https://github.com/que-rb/que/issues/247#issuecomment-595258236
+If that patch is included then que-scheduler will work. This setup is tested, but is not supported.
+
+
 ## Inspiration
 
 This gem was inspired by the makers of the excellent [Que](https://github.com/chanks/que) job scheduler gem. 

--- a/lib/que/scheduler/schedule.rb
+++ b/lib/que/scheduler/schedule.rb
@@ -36,10 +36,9 @@ module Que
         end
 
         def from_hash(config_hash)
-          config_hash.to_h do |name, defined_job_hash|
-            name_str = name.to_s
-            [name_str, hash_item_to_defined_job(name_str, defined_job_hash)]
-          end
+          config_hash
+            .map { |name, defined_job_hash| hash_item_to_defined_job(name.to_s, defined_job_hash) }
+            .index_by(&:name)
         end
 
         def hash_item_to_defined_job(name, defined_job_hash_in)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,5 @@
 require "bundler/setup"
 
-if RUBY_VERSION.start_with?("3") && Gem.loaded_specs["activesupport"].version.to_s.start_with?("5")
-  puts "Rails 5 does not work with Ruby 3"
-  # Allow the CI to continue the ruby test matrix
-  exit ENV["CI"] == "true" ? 0 : 1
-end
-
 require "pry-byebug"
 require "coveralls"
 Coveralls.wear!
@@ -36,6 +30,19 @@ end
 Bundler.require :default, :development
 
 Dir["#{__dir__}/../spec/support/**/*.rb"].sort.each { |f| require f }
+
+if RUBY_VERSION.start_with?("3") && Gem.loaded_specs["activesupport"].version.to_s.start_with?("5")
+  puts "Rails 5 does not work with Ruby 3"
+  # Allow the CI to continue the ruby test matrix
+  # rubocop:disable Style/SymbolProc
+  RSpec.configure do |config|
+    config.around(:each) do |example|
+      example.skip
+    end
+  end
+  # rubocop:enable Style/SymbolProc
+  return
+end
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This adds a change to the `from_hash` method so que-scheduler will work with ruby 2.5. However, this configuration is unsupported.

It also adds the que 0.x / rails 6.x patch and tests it.
