### PR TITLE
refactor: quieter logs for liveness messages

### DIFF
--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -33,7 +33,7 @@ module Que
             scheduler_job_args, scheduler_job_args.as_time, result.job_dictionary, enqueued_jobs
           )
           # Only now we're sure nothing errored, log the results
-          logs.each { |str| ::Que.log(event: :"que-scheduler", message: str) }
+          logs.each { |str| ::Que.log(level: :debug, event: :"que-scheduler", message: str) }
         end
       end
 


### PR DESCRIPTION
The default log level is info which is also the log level in Rails applications that's still visible by default.

Because it's mostly useful for debugging, this change lowers the log level.

Closes #326 