### PR TITLE
Fix re-enqueing with new Que version

### DIFF
--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -68,10 +68,10 @@ module Que
         enqueued_job = SchedulerJob.enqueue(
           job_options: {
             queue: Que::Scheduler.configuration.que_scheduler_queue,
-            last_run_time: last_full_execution.iso8601,
-            job_dictionary: job_dictionary,
             run_at: next_run_at,
-          }
+          },
+          last_run_time: last_full_execution.iso8601,
+          job_dictionary: job_dictionary,
         )
 
         # rubocop:disable Style/GuardClause This reads better as a conditional

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -33,7 +33,7 @@ module Que
             scheduler_job_args, scheduler_job_args.as_time, result.job_dictionary, enqueued_jobs
           )
           # Only now we're sure nothing errored, log the results
-          logs.each { |str| ::Que.log(event: :"que-scheduler", message: str) }
+          logs.each { |str| ::Que.log(level: :debug, event: :"que-scheduler", message: str) }
         end
       end
 

--- a/lib/que/scheduler/scheduler_job.rb
+++ b/lib/que/scheduler/scheduler_job.rb
@@ -66,10 +66,12 @@ module Que
         # And rerun...
         next_run_at = scheduler_job_args.as_time.beginning_of_minute + SCHEDULER_FREQUENCY
         enqueued_job = SchedulerJob.enqueue(
-          queue: Que::Scheduler.configuration.que_scheduler_queue,
-          last_run_time: last_full_execution.iso8601,
-          job_dictionary: job_dictionary,
-          run_at: next_run_at
+          job_options: {
+            queue: Que::Scheduler.configuration.que_scheduler_queue,
+            last_run_time: last_full_execution.iso8601,
+            job_dictionary: job_dictionary,
+            run_at: next_run_at,
+          }
         )
 
         # rubocop:disable Style/GuardClause This reads better as a conditional


### PR DESCRIPTION
The new version of Que currently under development in greensync/que#ruby3 wants job options to be passed in a named `job_options` argument.

Otherwise they will be ignored and run in a continuous loop.

Closes #326 