### PR TITLE
Formalise que_scheduler_check_job_exists function change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Formalise que_scheduler_check_job_exists function change [#334](https://github.com/hlascelles/que-scheduler/pull/335)
 - Remove Ruby 2.5, Ruby 2.6 and Que 0.12.x support [#334](https://github.com/hlascelles/que-scheduler/pull/334)
 
 ## 4.2.2 (2022-02-23)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ resque-scheduler files, but with additional features.
     ```ruby
     class CreateQueSchedulerSchema < ActiveRecord::Migration
       def change
-        Que::Scheduler::Migrations.migrate!(version: 6)
+        Que::Scheduler::Migrations.migrate!(version: 7)
       end
     end
     ```
@@ -211,7 +211,7 @@ performed.
 ```ruby
 class CreateQueSchedulerSchema < ActiveRecord::Migration
   def change
-    Que::Scheduler::Migrations.migrate!(version: 6)
+    Que::Scheduler::Migrations.migrate!(version: 7)
   end
 end
 ```

--- a/lib/que/scheduler/migrations/6/up.sql
+++ b/lib/que/scheduler/migrations/6/up.sql
@@ -13,7 +13,7 @@ DECLARE
 BEGIN
     IF OLD.job_class = 'Que::Scheduler::SchedulerJob' THEN
         IF NOT que_scheduler_check_job_exists() THEN
-            raise exception 'Deletion of que_scheduler job prevented. Deleting the que_scheduler job is almost certainly a mistake.';
+            raise exception 'Deletion of que_scheduler job % prevented. Deleting the que_scheduler job is almost certainly a mistake.', OLD.job_id;
         END IF;
     END IF;
     RETURN OLD;

--- a/lib/que/scheduler/migrations/7/down.sql
+++ b/lib/que/scheduler/migrations/7/down.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION que_scheduler_prevent_job_deletion() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+BEGIN
+    IF OLD.job_class = 'Que::Scheduler::SchedulerJob' THEN
+        IF NOT que_scheduler_check_job_exists() THEN
+            raise exception 'Deletion of que_scheduler job % prevented. Deleting the que_scheduler job is almost certainly a mistake.', OLD.job_id;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$BODY$
+LANGUAGE 'plpgsql';

--- a/lib/que/scheduler/migrations/7/up.sql
+++ b/lib/que/scheduler/migrations/7/up.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION que_scheduler_prevent_job_deletion() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+BEGIN
+    IF OLD.job_class = 'Que::Scheduler::SchedulerJob' THEN
+        IF NOT que_scheduler_check_job_exists() THEN
+            raise exception 'Deletion of que_scheduler job prevented. Deleting the que_scheduler job is almost certainly a mistake.';
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$BODY$
+LANGUAGE 'plpgsql';

--- a/spec/que/scheduler/migrations_spec.rb
+++ b/spec/que/scheduler/migrations_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Que::Scheduler::Migrations do
       ::Que::Scheduler::SchedulerJob.enqueue
       ::Que::Scheduler::StateChecks.check
 
+      expect(described_class.db_version).to eq(7)
+
+      # Check 7 change down
+      described_class.migrate!(version: 6)
       expect(described_class.db_version).to eq(6)
 
       migration_5_index = "index_que_scheduler_audit_on_scheduler_job_id"
@@ -109,6 +113,10 @@ RSpec.describe Que::Scheduler::Migrations do
       check_index_existence(migration_6_index, false)
       described_class.migrate!(version: 6)
       check_index_existence(migration_6_index, true)
+
+      # Check 7 change up
+      described_class.migrate!(version: 7)
+      expect(described_class.db_version).to eq(7)
 
       Que::Scheduler::StateChecks.check
     end


### PR DESCRIPTION
This changed in a PR without an accompanying migration. This may cause structure diffs when run on a clean DB. We should perform the change with a migration for it to be correct in all environments.
