### PR TITLE
Cut gem 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
-## UNRELEASED
+## 6.0.0 (2025-06-03) 
 
-BREAKING CHANGES:
-- Remove automatic scheduler job enqueueing in migrations [#549](https://github.com/hlascelles/que-scheduler/pull/549)
+- Add trusted publishing [#550](https://github.com/hlascelles/que-scheduler/pull/550)
+- BREAKING CHANGE: Remove automatic scheduler job enqueueing in migrations [#549](https://github.com/hlascelles/que-scheduler/pull/549)
 - Drop support for Que 0.x and Que 1.x [#548](https://github.com/hlascelles/que-scheduler/pull/548)
-
 - Dependency updates and quality improvements [#534](https://github.com/hlascelles/que-scheduler/pull/534)
 
-## 5.1.1  (2024-08-21)
+## 5.1.1 (2024-08-21)
 
 - Update fugit requirement to prevent https://github.com/floraison/fugit/issues/104 [#506](https://github.com/hlascelles/que-scheduler/pull/506)
 
-## 5.1.0  (2024-04-07)
+## 5.1.0 (2024-04-07)
 
 - Explicit Rails 7.0 and 7.1 support [#474](https://github.com/hlascelles/que-scheduler/pull/474)
 
-## 5.0.0  (2024-03-10)
+## 5.0.0 (2024-03-10)
 
 - Add primary key to audit enqueued table [#456](https://github.com/hlascelles/que-scheduler/pull/456). Note, this requires a migration version "8"
   to be run which will lock and rewrite the `que_scheduler_audit_enqueued` table. Check how large

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    que-scheduler (5.1.1)
+    que-scheduler (6.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)

--- a/gemfiles/activejob_7_0_que_2_x.gemfile.lock
+++ b/gemfiles/activejob_7_0_que_2_x.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (5.1.1)
+    que-scheduler (6.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)

--- a/gemfiles/activejob_7_1_que_2_x.gemfile.lock
+++ b/gemfiles/activejob_7_1_que_2_x.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (5.1.1)
+    que-scheduler (6.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)

--- a/gemfiles/activesupport_6_que_2_x.gemfile.lock
+++ b/gemfiles/activesupport_6_que_2_x.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (5.1.1)
+    que-scheduler (6.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = "5.1.1".freeze
+    VERSION = "6.0.0".freeze
   end
 end


### PR DESCRIPTION
# Description

This cuts gem 6.0.0 with a breaking change: the scheduler job must be explicitly scheduled in migrations: 

```ruby
class Migration1 < ActiveRecord::Migration[6.0]
  def change
    Que.migrate!(version: 3)
    Que::Scheduler::Migrations.migrate!(version: 6)
    Que::Scheduler::Migrations.reenqueue_scheduler_if_missing
  end
end
```