### PR TITLE
Replace Hashie::Dash with T::Struct

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,76 @@
+# LLM Agent Instructions for `que-scheduler` Repository
+
+This document provides guidance and best practices for LLM coding agents working on the `que-scheduler` codebase.
+
+## General Principles:
+
+*   **Understand the Goal:** Before making changes, ensure you have a clear understanding of the issue or feature request. Ask for clarification if needed.
+*   **Targeted Changes:** Strive to make minimal, targeted changes. Avoid altering unrelated code or reformatting files unnecessarily, as this can introduce noise and potential regressions.
+*   **Read Existing Code:** Familiarize yourself with the surrounding code and patterns before introducing new logic. Aim for consistency with the existing style.
+*   **Dependencies:** Be mindful of adding new gem dependencies. Only add them if necessary and ensure they are added to the `que-scheduler.gemspec` file.
+*   **Testing is Crucial:** All code changes *must* be accompanied by tests, or existing tests must be updated. Changes should not be submitted if tests are failing.
+
+## Development Workflow:
+
+1.  **Create a Plan:** Before writing code, outline the steps you will take. Use the `set_plan` tool.
+2.  **Implement Changes:** Write or modify the code according to your plan.
+3.  **Write/Update Tests:** Ensure your changes are covered by RSpec tests.
+4.  **Run Tests:** Execute the test suite to confirm your changes pass and haven't broken existing functionality.
+5.  **Commit and Submit:** Use clear and descriptive commit messages.
+
+## Running Tests (`./specs.sh`):
+
+Executing tests is a critical step. The primary script for running tests is `./specs.sh`.
+
+### Test Environment Prerequisites:
+
+*   **Ruby:** Version 3.0 or higher (CI uses 3.2, 3.3, 3.4).
+*   **Bundler:** For Ruby gem management.
+    *   Ensure it's installed (`gem install bundler`).
+    *   Install project dependencies: `bundle install`.
+*   **PostgreSQL:** Version 9.6 is used in CI.
+    *   The tests require a running PostgreSQL instance.
+    *   Connection details (likely expected via environment variables or default Rails conventions):
+        *   Host: (e.g., `localhost` or a Docker container IP)
+        *   Port: `5432`
+        *   User: `postgres`
+        *   Password: `postgres`
+        *   Database: `postgres` (or a specific test database name)
+*   **Environment Setup:** The CI workflow (`.github/workflows/specs.yml`) is the definitive source for setup:
+    1.  `actions/checkout@v4`
+    2.  `ruby/setup-ruby@v1` (this step usually handles Bundler installation)
+    3.  `./specs.sh` (runs the RSpec tests)
+    4.  `./quality.sh` (runs linters/static analysis)
+
+### To Run Tests Locally (Conceptual):
+
+1.  Ensure Ruby (e.g., 3.2) is installed and active.
+2.  Install Bundler: `gem install bundler`.
+3.  Navigate to the project root.
+4.  Install dependencies: `bundle install`.
+5.  Ensure a PostgreSQL 9.6 server is running and accessible with credentials: user `postgres`, password `postgres` on the default port `5432`, with a database named `postgres`. (Environment variables like `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` might be respected by the test setup or `database.yml` if used).
+6.  Execute the test script: `./specs.sh`.
+
+**Note:** If `./specs.sh` fails due to environment issues, consult the CI configuration in `.github/workflows/specs.yml` for the exact setup commands and service configurations.
+
+## Code Style and Quality:
+
+*   **RuboCop:** This project likely uses RuboCop for linting and style enforcement. Pay attention to its output and try to fix any reported offenses. The `./quality.sh` script might run RuboCop.
+*   **Comments:** Add comments to explain complex logic or non-obvious decisions.
+*   **Sorbet:** This project is transitioning to Sorbet for type checking.
+    *   When modifying existing files that use Sorbet, ensure type signatures (`sig`) are updated or added appropriately.
+    *   For new classes or methods, try to add Sorbet type signatures.
+    *   `T::Struct` is preferred over `Hashie::Dash` for structured data.
+
+## Specific Gotchas for this Repository:
+
+*   **`Hashie::Dash` to `T::Struct` Migration:** The project is moving from `Hashie::Dash` to `T::Struct`. When encountering `Hashie::Dash`, the goal is to replace it. This involves:
+    *   Changing inheritance from `Hashie::Dash` to `T::Struct`.
+    *   Replacing `property` with `const`.
+    *   Defining types for each `const` (e.g., `String`, `T.nilable(Integer)`, `T::Array[String]`).
+    *   Removing `include Hashie::Extensions::Dash::PropertyTranslation`.
+    *   Adjusting constructor calls (`new(...)`) and data access to align with `T::Struct` conventions.
+    *   Adding `extend T::Sig` to the class and `sig` blocks to methods.
+*   **Gemfile vs. Gemspec:** Runtime dependencies should be in `que-scheduler.gemspec`. Development dependencies are typically in the `Gemfile` or also in the `gemspec`'s `add_development_dependency` section.
+
+By following these guidelines, you can contribute effectively to the `que-scheduler` repository. If you are unsure about any step, please ask for clarification.

--- a/lib/que/scheduler/enqueueing_calculator.rb
+++ b/lib/que/scheduler/enqueueing_calculator.rb
@@ -1,14 +1,24 @@
+require "sorbet-runtime"
 require "fugit"
 
 module Que
   module Scheduler
     module EnqueueingCalculator
-      class Result < Hashie::Dash
-        property :missed_jobs, required: true
-        property :job_dictionary, required: true
+      class Result < T::Struct
+        extend T::Sig
+        const :missed_jobs, T::Array[ToEnqueue]
+        const :job_dictionary, T::Array[String]
       end
 
       class << self
+        extend T::Sig
+
+        sig {
+          params(
+            scheduler_config: T::Array[DefinedJob],
+            scheduler_job_args: SchedulerJobArgs
+          ).returns(Result)
+        }
         def parse(scheduler_config, scheduler_job_args)
           job_dictionary = []
 

--- a/lib/que/scheduler/to_enqueue.rb
+++ b/lib/que/scheduler/to_enqueue.rb
@@ -1,59 +1,79 @@
+require "sorbet-runtime"
 require "que"
 
 # This module uses polymorphic dispatch to centralise the differences between supporting Que::Job
 # and other job systems.
 module Que
   module Scheduler
-    class ToEnqueue < Hashie::Dash
-      property :args, required: true, default: []
-      property :queue
-      property :priority
-      property :run_at, required: true
-      property :job_class, required: true
+    class ToEnqueue < T::Struct
+      extend T::Sig
+
+      const :args, T.any(T::Array[T.untyped], T::Hash[Symbol, T.untyped]), default: []
+      const :queue, T.nilable(String)
+      const :priority, T.nilable(Integer)
+      const :run_at, Time
+      const :job_class, Class
 
       class << self
+        extend T::Sig
+
+        sig { params(options: T::Hash[Symbol, T.untyped]).returns(ToEnqueue) }
         def create(options)
-          type_from_job_class(options.fetch(:job_class)).new(
-            options.merge(run_at: Que::Scheduler::Db.now)
+          # Ensure options keys are symbols for T::Struct
+          symbolized_options = options.transform_keys(&:to_sym)
+          job_class_val = symbolized_options.fetch(:job_class)
+          # Sorbet needs the exact type for the constructor
+          klass = type_from_job_class(job_class_val)
+          raise "Unknown job_class type #{job_class_val}" if klass.nil?
+
+          klass.new(
+            symbolized_options.merge(run_at: Que::Scheduler::Db.now)
           )
         end
 
+        sig { params(job_class: Class).returns(T::Boolean) }
         def valid_job_class?(job_class)
-          type_from_job_class(job_class).present?
+          !type_from_job_class(job_class).nil?
         end
 
+        sig { returns(T::Boolean) }
         def active_job_defined?
           Object.const_defined?(:ActiveJob)
         end
 
+        sig { returns(T.nilable(Gem::Version)) }
         def active_job_version
           Gem.loaded_specs["activejob"]&.version
         end
 
+        sig { returns(T::Boolean) }
         def active_job_version_supports_queues?
           # Supporting queue name in ActiveJob was removed in Rails 4.2.3
           # https://github.com/rails/rails/pull/19498
           # and readded in Rails 6.0.3
           # https://github.com/rails/rails/pull/38635
-          ToEnqueue.active_job_version && ToEnqueue.active_job_version >=
-            Gem::Version.create("6.0.3")
+          active_job_version && active_job_version >= Gem::Version.create("6.0.3")
         end
 
-        private def type_from_job_class(job_class)
+        private
+
+        sig { params(job_class: Class).returns(T.nilable(T.class_of(ToEnqueue))) }
+        def type_from_job_class(job_class)
           types.each do |type, implementation|
-            return implementation if job_class < type
+            return implementation if job_class <= type
           end
           nil
         end
 
-        private def types
+        sig { returns(T::Hash[Class, T.class_of(ToEnqueue)]) }
+        def types
           @types ||=
             begin
               hash = {
                 ::Que::Job => QueJobType,
               }
-              hash[::ActiveJob::Base] = ActiveJobType if ToEnqueue.active_job_defined?
-              hash
+              hash[::ActiveJob::Base] = ActiveJobType if active_job_defined?
+              T.let(hash, T::Hash[Class, T.class_of(ToEnqueue)])
             end
         end
       end
@@ -61,27 +81,39 @@ module Que
 
     # For jobs of type Que::Job
     class QueJobType < ToEnqueue
+      extend T::Sig
+
+      sig { returns(T.nilable(EnqueuedJobType)) }
       def enqueue
-        job_settings = to_h.slice(:queue, :priority, :run_at).compact
-        job = Que::Scheduler::DbSupport.enqueue_a_job(
+        job_settings = {
+          queue: queue,
+          priority: priority,
+          run_at: run_at,
+        }.compact
+        # Ensure args is an Array for Que::Job
+        job_args = args.is_a?(Hash) ? [args] : Array(args)
+        db_job = Que::Scheduler::DbSupport.enqueue_a_job(
           job_class,
           job_settings,
-          args
+          job_args
         )
 
-        return nil if job.nil? || !job # nil in Rails < 6.1, false after.
+        return nil if db_job.nil? || !db_job # nil in Rails < 6.1, false after.
 
         # Now read the just inserted job back out of the DB to get the actual values that will
         # be used when the job is worked.
-        values = Que::Scheduler::DbSupport.job_attributes(job).slice(
+        values = Que::Scheduler::DbSupport.job_attributes(db_job).slice(
           :args, :queue, :priority, :run_at, :job_class, :job_id
-        )
+        ).transform_keys(&:to_sym) # Ensure keys are symbols for T::Struct
         EnqueuedJobType.new(values)
       end
     end
 
     # For jobs of type ActiveJob
     class ActiveJobType < ToEnqueue
+      extend T::Sig
+
+      sig { returns(T.nilable(EnqueuedJobType)) }
       def enqueue
         job = enqueue_active_job
 
@@ -91,15 +123,16 @@ module Que
         EnqueuedJobType.new(enqueued_values)
       end
 
+      sig { params(job: T.untyped).returns(T::Hash[Symbol, T.untyped]) }
       def calculate_enqueued_values(job)
         # Now read the just inserted job back out of the DB to get the actual values that will
         # be used when the job is worked.
         data = JSON.parse(job.to_json, symbolize_names: true)
 
-        scheduled_at = self.class.extract_scheduled_at(data[:scheduled_at])
+        scheduled_at = self.class.extract_scheduled_at(T.let(data[:scheduled_at], T.untyped))
 
         # Rails didn't support queues for ActiveJob for a while
-        used_queue = data[:queue_name] if ToEnqueue.active_job_version_supports_queues?
+        used_queue = data[:queue_name] if self.class.active_job_version_supports_queues?
 
         # We can't get the priority out of the DB, as the returned `job` doesn't give us access
         # to the underlying ActiveJob that was scheduled. We have no option but to assume
@@ -112,11 +145,12 @@ module Que
           queue: used_queue,
           priority: assume_used_priority,
           run_at: scheduled_at,
-          job_class: job_class.to_s,
+          job_class: job_class.to_s, # job_class in EnqueuedJobType is a String
           job_id: data.fetch(:provider_job_id),
         }
       end
 
+      sig { returns(T.untyped) } # Returns an ActiveJob::Base instance or similar
       def enqueue_active_job
         job_settings = {
           priority: priority,
@@ -125,16 +159,19 @@ module Que
         }.compact
 
         job_class_set = job_class.set(**job_settings)
-        if args.is_a?(Hash)
-          job_class_set.perform_later(**args)
+        current_args = args # To satisfy Sorbet's ExperimentalPass
+        if current_args.is_a?(Hash)
+          job_class_set.perform_later(**current_args)
         else
-          job_class_set.perform_later(*args)
+          job_class_set.perform_later(*current_args)
         end
       end
 
       class << self
+        extend T::Sig
         # ActiveJob scheduled_at is returned as a float, or a string post Rails 7.1,
         # and we want a Time for consistency
+        sig { params(scheduled_at: T.untyped).returns(T.nilable(Time)) }
         def extract_scheduled_at(scheduled_at)
           # rubocop:disable Style/EmptyElse
           if scheduled_at.is_a?(Float)
@@ -142,7 +179,8 @@ module Que
           elsif scheduled_at.is_a?(String)
             Que::Scheduler::TimeZone.time_zone.parse(scheduled_at)
           else
-            nil
+            # Sorbet needs an explicit return type if the block could be empty
+            T.let(nil, T.nilable(Time))
           end
           # rubocop:enable Style/EmptyElse
         end
@@ -151,13 +189,14 @@ module Que
 
     # A value object returned after a job has been enqueued. This is necessary as Que (normal) and
     # ActiveJob return very different objects from the `enqueue` call.
-    class EnqueuedJobType < Hashie::Dash
-      property :args
-      property :queue
-      property :priority
-      property :run_at, required: true
-      property :job_class, required: true
-      property :job_id, required: true
+    class EnqueuedJobType < T::Struct
+      extend T::Sig
+      const :args, T.untyped # Can be Array or Hash
+      const :queue, T.nilable(String)
+      const :priority, T.nilable(Integer)
+      const :run_at, Time
+      const :job_class, String # Stored as string from ActiveJob, keep consistent
+      const :job_id, T.any(Integer, String) # Que uses Integer, AJ uses String
     end
   end
 end

--- a/que-scheduler.gemspec
+++ b/que-scheduler.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "fugit", "~> 1.1", ">= 1.11.1" # 1.11.1 prevents https://github.com/floraison/fugit/issues/104
-  spec.add_dependency "hashie", ">= 3", "< 6"
   spec.add_dependency "que", ">= 2.0", "< 3.0"
+  spec.add_dependency "sorbet-runtime", "~> 0.5.11181"
 
   spec.add_development_dependency "activerecord", ">= 5.0", "< 8.0"
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
This commit replaces all usages of `Hashie::Dash` with `T::Struct` from the `sorbet-runtime` gem.

Key changes:
- Updated `DefinedJob`, `EnqueueingCalculator::Result`, `SchedulerJobArgs`, `ToEnqueue`, `QueJobType`, and `EnqueuedJobType` classes.
- Added `sorbet-runtime` as a dependency in the gemspec.
- Removed `hashie` as a dependency from the gemspec.
- Added `sig` annotations for type checking with Sorbet.
- Created `.github/copilot-instructions.md` to provide guidance for LLM agents working on this repository.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

You should be able to run the full test suite locally.

In one terminal, run a postgres docker container:

```bash
docker run -p 5430:5432 postgres:9.6.0
```

In another, run the full test suite (takes about 30 seconds)

```bash
./appraisal.sh
```
