### PR TITLE
Use ISO 8601 every_event args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 6.0.0 (2026-02-23)
+## 7.0.0 (2026-05-15)
+
+- Use ISO 8601 every_event args [#598](https://github.com/hlascelles/que-scheduler/pull/598)
+
+## 6.0.1 (2026-02-23)
 
 - Add ruby 4.0 specs [#595](https://github.com/hlascelles/que-scheduler/pull/595)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    que-scheduler (6.0.1)
+    que-scheduler (7.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)

--- a/gemfiles/activejob_7_0.gemfile.lock
+++ b/gemfiles/activejob_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (6.0.1)
+    que-scheduler (7.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)
@@ -413,7 +413,7 @@ CHECKSUMS
   pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   que (2.4.1) sha256=a7ba7679d13ef499da5de30a147f910e9e6d9d60cad15f8691a0b0b5bc758a7b
-  que-scheduler (6.0.1)
+  que-scheduler (7.0.0)
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (2.2.23) sha256=a8fe9d7e07064770b8ec123663fded8a59ef7e2b6db5cda7173d45a5718ab69c

--- a/gemfiles/activejob_7_1.gemfile.lock
+++ b/gemfiles/activejob_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (6.0.1)
+    que-scheduler (7.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)
@@ -450,7 +450,7 @@ CHECKSUMS
   pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   que (2.4.1) sha256=a7ba7679d13ef499da5de30a147f910e9e6d9d60cad15f8691a0b0b5bc758a7b
-  que-scheduler (6.0.1)
+  que-scheduler (7.0.0)
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    que-scheduler (6.0.1)
+    que-scheduler (7.0.0)
       activesupport (>= 6.0)
       fugit (~> 1.1, >= 1.11.1)
       hashie (>= 3, < 6)
@@ -445,7 +445,7 @@ CHECKSUMS
   pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   que (2.4.1) sha256=a7ba7679d13ef499da5de30a147f910e9e6d9d60cad15f8691a0b0b5bc758a7b
-  que-scheduler (6.0.1)
+  que-scheduler (7.0.0)
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2

--- a/lib/que/scheduler/defined_job.rb
+++ b/lib/que/scheduler/defined_job.rb
@@ -116,7 +116,7 @@ module Que
 
         if schedule_type == DefinedJob::DEFINED_JOB_TYPE_EVERY_EVENT
           missed_times.map do |time_missed|
-            ToEnqueue.create(options.merge(args: [time_missed] + args_array))
+            ToEnqueue.create(options.merge(args: [time_missed.iso8601] + args_array))
           end
         else
           [ToEnqueue.create(options.merge(args: args_array))]

--- a/lib/que/scheduler/version.rb
+++ b/lib/que/scheduler/version.rb
@@ -1,5 +1,5 @@
 module Que
   module Scheduler
-    VERSION = "6.0.1".freeze
+    VERSION = "7.0.0".freeze
   end
 end

--- a/spec/que/scheduler/enqueueing_calculator_spec.rb
+++ b/spec/que/scheduler/enqueueing_calculator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
 
     # Now tip it over the required time by a 1 second so it should run.
     # Since it is an `every_event` job it should receive the schedule time as an arg.
-    expected_arg_time = Time.zone.parse("2017-12-01T07:05:00-08")
+    expected_arg_time = Time.zone.parse("2017-12-01T07:05:00-08").iso8601
     run_test_with_times(
       last_run, this_run + 1.second, [{ job_class: TimezoneTestJob, args: [expected_arg_time] }]
     )
@@ -90,14 +90,17 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
   end
 
   it "enqueues an every_event job once with date arg if seen to be missed once" do
+    arg_time = Time.zone.parse("2017-10-08T06:10:00").iso8601
     run_test(
       "2017-10-08T06:09:59",
       2.seconds,
-      [{ job_class: DailyTestJob, args: [Time.zone.parse("2017-10-08T06:10:00"), "Single arg"] }]
+      [{ job_class: DailyTestJob, args: [arg_time, "Single arg"] }]
     )
   end
 
   it "enqueues an every_event job multiple times if missed repeatedly" do
+    arg_time1 = Time.zone.parse("2017-10-08T06:10:00").iso8601
+    arg_time2 = Time.zone.parse("2017-10-09T06:10:00").iso8601
     run_test(
       "2017-10-08T02:09:59",
       2.days,
@@ -110,29 +113,29 @@ RSpec.describe Que::Scheduler::EnqueueingCalculator do
         { job_class: SpecifiedByClassTestJob, args: ["One arg"] },
         # These are "every_event", so all their missed schedules are enqueued, with that
         # Time as an argument.
-        { job_class: DailyTestJob, args: [Time.zone.parse("2017-10-08T06:10:00"), "Single arg"] },
-        { job_class: DailyTestJob, args: [Time.zone.parse("2017-10-09T06:10:00"), "Single arg"] },
+        { job_class: DailyTestJob, args: [arg_time1, "Single arg"] },
+        { job_class: DailyTestJob, args: [arg_time2, "Single arg"] },
         {
           job_class: TwiceDailyTestJob,
-          args: [Time.zone.parse("2017-10-08T11:10:00")],
+          args: [Time.zone.parse("2017-10-08T11:10:00").iso8601],
           queue: "backlog",
           priority: 35,
         },
         {
           job_class: TwiceDailyTestJob,
-          args: [Time.zone.parse("2017-10-08T16:10:00")],
+          args: [Time.zone.parse("2017-10-08T16:10:00").iso8601],
           queue: "backlog",
           priority: 35,
         },
         {
           job_class: TwiceDailyTestJob,
-          args: [Time.zone.parse("2017-10-09T11:10:00")],
+          args: [Time.zone.parse("2017-10-09T11:10:00").iso8601],
           queue: "backlog",
           priority: 35,
         },
         {
           job_class: TwiceDailyTestJob,
-          args: [Time.zone.parse("2017-10-09T16:10:00")],
+          args: [Time.zone.parse("2017-10-09T16:10:00").iso8601],
           queue: "backlog",
           priority: 35,
         },


### PR DESCRIPTION
When que-scheduler passes in an every event string, it should be using an ISO 8601 timestamp, but currently it is just a `Time.to_s`.

This PR fixes that.

ie it was: `"2017-12-01 19:05:00 +0400"`
it is now: `"2017-12-01T19:05:00+04:00"`