### PR TITLE
Use scheduler queue for audit clear-down job

### DIFF
--- a/lib/que/scheduler/jobs/que_scheduler_audit_clear_down_job.rb
+++ b/lib/que/scheduler/jobs/que_scheduler_audit_clear_down_job.rb
@@ -26,6 +26,7 @@ module Que
 
         # Very low priority
         self.priority = 100
+        self.queue = -> { Que::Scheduler.configuration.que_scheduler_queue }
 
         def run(options)
           retain_row_count = options.symbolize_keys.fetch(:retain_row_count)

--- a/spec/que/scheduler/jobs/que_scheduler_audit_clear_down_job_spec.rb
+++ b/spec/que/scheduler/jobs/que_scheduler_audit_clear_down_job_spec.rb
@@ -3,6 +3,27 @@ require "spec_helper"
 RSpec.describe Que::Scheduler::Jobs::QueSchedulerAuditClearDownJob do
   include_context "when audit testing"
 
+  describe ".enqueue" do
+    it "uses the configured scheduler queue" do
+      Que::Scheduler.configuration.que_scheduler_queue = "low_priority"
+
+      job = described_class.enqueue(retain_row_count: 1)
+      queue = Que::Scheduler::DbSupport.job_attributes(job).fetch(:queue)
+
+      expect(queue).to eq("low_priority")
+    end
+
+    it "allows the queue to be overridden when enqueued" do
+      job = described_class.enqueue(
+        retain_row_count: 1,
+        job_options: { queue: "maintenance" }
+      )
+      queue = Que::Scheduler::DbSupport.job_attributes(job).fetch(:queue)
+
+      expect(queue).to eq("maintenance")
+    end
+  end
+
   def insert_test_rows
     now = Que::Scheduler::Db.now
     initial = 10


### PR DESCRIPTION
# Description

The audit clear-down job did not define a queue, so Que fell back to its own default instead of the scheduler queue configured by `QUE_SCHEDULER_QUEUE` or `Que::Scheduler.configure`.

The job now resolves its default queue from the current scheduler configuration at enqueue time. An explicitly supplied queue still takes precedence.

Fixes #567

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- focused audit clear-down job specs: 7 examples, 0 failures
- ActiveJob 7.0, ActiveJob 7.1, and Rails 8.1 appraisal suites excluding the migration spec: 303 examples, 0 failures
- no-Rails integration tests under all three appraisals
- `./quality.sh` (Fasterer, RuboCop, and Reek)
- gem build and `git diff --check`

The repository's migration spec has one pre-existing failure on local PostgreSQL 16 (`cannot CREATE INDEX ... because it has pending trigger events`). The same 7-example migration spec produces the same single failure on an unmodified `origin/master` worktree. The project CI uses PostgreSQL 9.6.
